### PR TITLE
add get and set function for "blockLRW" flag of CdefSlave class

### DIFF
--- a/pysoem/pysoem.pyx
+++ b/pysoem/pysoem.pyx
@@ -831,6 +831,12 @@ cdef class CdefSlave:
         
     od = property(_get_od)
 
+    def get_block_lrw(self):
+        return self._ec_slave.blockLRW
+
+    def set_block_lrw(self, val):
+        self._ec_slave.blockLRW = val
+
 
 cdef class CdefCoeObject:
     """Object info for objects in the object dictionary.


### PR DESCRIPTION
Several ethercat devices based on the older TI Sitara processor cannot be used by pysoem, because they do not support LRW. The proposed workaround by TI for this issue when using SOEM is to set the blockLRW flag in the slave. 
To be able to do that out of pysoem, I added a set and a get function.
Any chance to get that in? Or is there already a way to do that which I overlooked?

Further description of the issue from TI forum is here:
https://e2e.ti.com/support/processors-group/processors/f/processors-forum/435658/ethercat-using-lrw-communication
and here:
https://e2e.ti.com/support/processors-group/processors/f/processors-forum/546383/am335x-ethercat-slave-errata-root-cause