### PR TITLE
Added function set_manualstatechange

### DIFF
--- a/pysoem/pysoem.pyx
+++ b/pysoem/pysoem.pyx
@@ -362,7 +362,20 @@ cdef class CdefMaster:
             int: Working Counter
         """
         return cpysoem.ecx_receive_processdata(&self._ecx_contextt, timeout)
+    
+    def set_manualstatechange(self, int manualstatechange):
+        """Set manualstatechange variable in context.
         
+        Flag to control legacy automatic state change or manual state change in functions
+        config_init() and config_map()
+        Flag value = 0 is legacy automatic state
+        Flag value > 0 and states must be handled manually
+        Args:
+            manualstatechange (int): The manual state change flag.
+        """
+
+        self._ecx_contextt.manualstatechange = manualstatechange
+
     def _get_slave(self, int pos):
         if pos < 0:
             raise IndexError('requested slave device is not available')

--- a/pysoem/pysoem.pyx
+++ b/pysoem/pysoem.pyx
@@ -148,7 +148,8 @@ cdef class CdefMaster:
     state = property(_get_state, _set_state)
     expected_wkc  = property(_get_expected_wkc)
     dc_time = property(_get_dc_time)
-    
+    manual_state_change = property(_get_manual_state_change, _set_manual_state_change)
+
     def __cinit__(self):
         self._ecx_contextt.port = &self._ecx_port
         self._ecx_contextt.slavelist = &self._ec_slave[0]
@@ -363,19 +364,6 @@ cdef class CdefMaster:
         """
         return cpysoem.ecx_receive_processdata(&self._ecx_contextt, timeout)
     
-    def set_manualstatechange(self, int manualstatechange):
-        """Set manualstatechange variable in context.
-        
-        Flag to control legacy automatic state change or manual state change in functions
-        config_init() and config_map()
-        Flag value = 0 is legacy automatic state
-        Flag value > 0 and states must be handled manually
-        Args:
-            manualstatechange (int): The manual state change flag.
-        """
-
-        self._ecx_contextt.manualstatechange = manualstatechange
-
     def _get_slave(self, int pos):
         if pos < 0:
             raise IndexError('requested slave device is not available')
@@ -406,6 +394,22 @@ cdef class CdefMaster:
 
         Note EtherCAT cycle here means the call of send_processdata and receive_processdata."""
         return self._ec_DCtime
+    
+    def _set_manual_state_change(self, int manual_state_change):
+        """Set manualstatechange variable in context.
+        
+        Flag to control legacy automatic state change or manual state change in functions
+        config_init() and config_map()
+        Flag value == 0 is legacy automatic state
+        Flag value != 0 and states must be handled manually
+        Args:
+            manual_state_change (int): The manual state change flag.
+        """
+        self._ecx_contextt.manualstatechange = manual_state_change
+
+    def _get_manual_state_change(self):        
+        return self._ecx_contextt.manualstatechange
+
         
         
 class SdoError(Exception):


### PR DESCRIPTION
Simply expose the flag `manualstatechange` to the Master class, so it can be set.

There are situations where one wants to run functions `config_init()` or `config_map()`  without slave states automatically being updated. This flag will allow full manual control over the slave states.