### PR TITLE
Checkout submodules in build_sdist

### DIFF
--- a/.github/workflows/manual_triggerd_build_and_upload_to_test_pypi.yml
+++ b/.github/workflows/manual_triggerd_build_and_upload_to_test_pypi.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/.github/workflows/release_triggerd_build_and_upload_to_pypi.yml
+++ b/.github/workflows/release_triggerd_build_and_upload_to_pypi.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Build sdist
         run: pipx run build --sdist


### PR DESCRIPTION
When building the sdist package the soem submodule was not checked out.
This lead to failing installs.

Fixes #108