### PR TITLE
fixup: example: DC sync on S=>O

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -78,8 +78,6 @@ class BasicExample:
             "Bx" + "".join(["H" for _ in range(len(rx_map_obj))]), len(rx_map_obj), *rx_map_obj)
         slave.sdo_write(index=0x1C12, subindex=0, data=rx_map_obj_bytes, ca=True)
 
-        slave.dc_sync(act=True, sync0_cycle_time=10_000_000)  # time is given in ns -> 10,000,000ns = 10ms
-
     def _processdata_thread(self):
         """Background thread that sends and receives the process-data frame in a 10ms interval."""
         while not self._pd_thread_stop_event.is_set():
@@ -138,6 +136,8 @@ class BasicExample:
         if self._master.state_check(pysoem.SAFEOP_STATE, timeout=50_000) != pysoem.SAFEOP_STATE:
             self._master.close()
             raise BasicExampleError("not all slaves reached SAFEOP state")
+        
+        slave.dc_sync(act=True, sync0_cycle_time=10_000_000)  # time is given in ns -> 10,000,000ns = 10ms
 
         self._master.state = pysoem.OP_STATE
 


### PR DESCRIPTION
There is a _potential_ mistake in example, which had me banging head for quite some time with my motor controller: DC sync needed be performed during `SAFEOP=>OP `transition, being first action. [[source](https://infosys.beckhoff.com/index.php?content=../content/1031/ethercatsystem/2469102219.html&id=),  search of `SAFE`]. At the same time, English source, claims it shall be performed during `PREOP=>OP` [[source](https://infosys.beckhoff.com/english.php?content=../content/1033/ethercatsystem/2469102219.html&id=), search for `PREOP`], so there is clearly some misaligned. IMO its safe to assume English is wrong, as:
* There is simply no `PREOP=>OP` transition. Only `PREOP=>SAFEOP` and then `SAFEOP=>OP`.
* Original language of docs was German, translated to English, that could explain mistake
* Checking other sources online (eg, images below), its clear that it shall be `SAFEOP=>OP`.
* (May be subjective) In case of LS Servo drivers, original example simple does not work, device never goes OP. Fixing to order of German docs/image below everything works like a charm.

(not official source though):
![Screenshot from 2023-07-31 21-24-05](https://github.com/bnjmnp/pysoem/assets/51450005/d8fc1008-0d2f-4f60-9c3f-61926d2d16ba)
![Screenshot from 2023-07-31 21-24-16](https://github.com/bnjmnp/pysoem/assets/51450005/e37f8265-2950-494a-a2db-dbe5ed168ce6)

I am not sure why it works in current example, I guess it depends per implementation, and some devices are less picky.

Hope this helps someone not to repeat my mistakes :) I can't find 100% solid and correct definition in EtherCAT standard when exactly this particular part shall be performed. Not sure this change shall be merged in right away, but wanted to raise this issue/inconsistency.