### PR TITLE
Add emergency message callback

### DIFF
--- a/pysoem/pysoem.pyx
+++ b/pysoem/pysoem.pyx
@@ -745,7 +745,10 @@ cdef class CdefSlave:
 
         cdef cpysoem.ec_errort err
         if cpysoem.ecx_poperror(self._ecx_contextt, &err):
-            self._raise_exception(&err)
+            if err.Etype == cpysoem.EC_ERR_TYPE_EMERGENCY:
+                self._on_emergency(&err)
+            else:
+                self._raise_exception(&err)
 
         return wkt
         


### PR DESCRIPTION
I think that it would be useful that instead of raising an exception when emergency messages are received, we could consume them via a callback function (similarly as it is done in the [CANopen library](https://github.com/christiansandberg/canopen/blob/master/canopen/emcy.py#L36)).  By doing so we don't interrupt the flow of the SDO read and SDO write operations.