### PR TITLE
Unblock python threads in SOEM blocking functions

### DIFF
--- a/osal/linux/osal.c
+++ b/osal/linux/osal.c
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the GNU General Public License version 2 with exceptions. See
+ * LICENSE file in the project root for full license information
+ */
+
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <osal.h>
+#include "Python.h"
+
+#define USECS_PER_SEC     1000000
+
+int osal_usleep (uint32 usec)
+{
+   struct timespec ts;
+   ts.tv_sec = usec / USECS_PER_SEC;
+   ts.tv_nsec = (usec % USECS_PER_SEC) * 1000;
+   /* usleep is deprecated, use nanosleep instead */
+   int result;
+   Py_BEGIN_ALLOW_THREADS
+   int result = nanosleep(&ts, NULL);
+   Py_END_ALLOW_THREADS
+   return result;
+}
+
+int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+   struct timespec ts;
+   int return_value;
+   (void)tz;       /* Not used */
+
+   /* Use clock_gettime to prevent possible live-lock.
+    * Gettimeofday uses CLOCK_REALTIME that can get NTP timeadjust.
+    * If this function preempts timeadjust and it uses vpage it live-locks.
+    * Also when using XENOMAI, only clock_gettime is RT safe */
+   return_value = clock_gettime(CLOCK_MONOTONIC, &ts);
+   tv->tv_sec = ts.tv_sec;
+   tv->tv_usec = ts.tv_nsec / 1000;
+   return return_value;
+}
+
+ec_timet osal_current_time(void)
+{
+   struct timeval current_time;
+   ec_timet return_value;
+
+   osal_gettimeofday(&current_time, 0);
+   return_value.sec = current_time.tv_sec;
+   return_value.usec = current_time.tv_usec;
+   return return_value;
+}
+
+void osal_time_diff(ec_timet *start, ec_timet *end, ec_timet *diff)
+{
+   if (end->usec < start->usec) {
+      diff->sec = end->sec - start->sec - 1;
+      diff->usec = end->usec + 1000000 - start->usec;
+   }
+   else {
+      diff->sec = end->sec - start->sec;
+      diff->usec = end->usec - start->usec;
+   }
+}
+
+void osal_timer_start(osal_timert * self, uint32 timeout_usec)
+{
+   struct timeval start_time;
+   struct timeval timeout;
+   struct timeval stop_time;
+
+   osal_gettimeofday(&start_time, 0);
+   timeout.tv_sec = timeout_usec / USECS_PER_SEC;
+   timeout.tv_usec = timeout_usec % USECS_PER_SEC;
+   timeradd(&start_time, &timeout, &stop_time);
+
+   self->stop_time.sec = stop_time.tv_sec;
+   self->stop_time.usec = stop_time.tv_usec;
+}
+
+boolean osal_timer_is_expired (osal_timert * self)
+{
+   struct timeval current_time;
+   struct timeval stop_time;
+   int is_not_yet_expired;
+
+   osal_gettimeofday(&current_time, 0);
+   stop_time.tv_sec = self->stop_time.sec;
+   stop_time.tv_usec = self->stop_time.usec;
+   is_not_yet_expired = timercmp(&current_time, &stop_time, <);
+
+   return is_not_yet_expired == FALSE;
+}
+
+void *osal_malloc(size_t size)
+{
+   return malloc(size);
+}
+
+void osal_free(void *ptr)
+{
+   free(ptr);
+}
+
+int osal_thread_create(void *thandle, int stacksize, void *func, void *param)
+{
+   int                  ret;
+   pthread_attr_t       attr;
+   pthread_t            *threadp;
+
+   threadp = thandle;
+   pthread_attr_init(&attr);
+   pthread_attr_setstacksize(&attr, stacksize);
+   ret = pthread_create(threadp, &attr, func, param);
+   if(ret < 0)
+   {
+      return 0;
+   }
+   return 1;
+}
+
+int osal_thread_create_rt(void *thandle, int stacksize, void *func, void *param)
+{
+   int                  ret;
+   pthread_attr_t       attr;
+   struct sched_param   schparam;
+   pthread_t            *threadp;
+
+   threadp = thandle;
+   pthread_attr_init(&attr);
+   pthread_attr_setstacksize(&attr, stacksize);
+   ret = pthread_create(threadp, &attr, func, param);
+   pthread_attr_destroy(&attr);
+   if(ret < 0)
+   {
+      return 0;
+   }
+   memset(&schparam, 0, sizeof(schparam));
+   schparam.sched_priority = 40;
+   ret = pthread_setschedparam(*threadp, SCHED_FIFO, &schparam);
+   if(ret < 0)
+   {
+      return 0;
+   }
+
+   return 1;
+}

--- a/osal/macosx/osal.c
+++ b/osal/macosx/osal.c
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the GNU General Public License version 2 with exceptions. See
+ * LICENSE file in the project root for full license information
+ */
+
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <osal.h>
+#include "Python.h"
+
+#define USECS_PER_SEC     1000000
+
+int osal_usleep (uint32 usec)
+{
+   struct timespec ts;
+   ts.tv_sec = usec / USECS_PER_SEC;
+   ts.tv_nsec = (usec % USECS_PER_SEC) * 1000;
+   /* usleep is deprecated, use nanosleep instead */
+   int result;
+   Py_BEGIN_ALLOW_THREADS
+   int result = nanosleep(&ts, NULL);
+   Py_END_ALLOW_THREADS
+   return result;
+}
+
+int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+   struct timespec ts;
+   int return_value;
+   (void)tz;       /* Not used */
+
+   /* Use clock_gettime to prevent possible live-lock.
+    * Gettimeofday uses CLOCK_REALTIME that can get NTP timeadjust.
+    * If this function preempts timeadjust and it uses vpage it live-locks.
+    * Also when using XENOMAI, only clock_gettime is RT safe */
+   return_value = clock_gettime(CLOCK_MONOTONIC, &ts);
+   tv->tv_sec = ts.tv_sec;
+   tv->tv_usec = ts.tv_nsec / 1000;
+   return return_value;
+}
+
+ec_timet osal_current_time(void)
+{
+   struct timeval current_time;
+   ec_timet return_value;
+
+   osal_gettimeofday(&current_time, 0);
+   return_value.sec = current_time.tv_sec;
+   return_value.usec = current_time.tv_usec;
+   return return_value;
+}
+
+void osal_time_diff(ec_timet *start, ec_timet *end, ec_timet *diff)
+{
+   if (end->usec < start->usec) {
+      diff->sec = end->sec - start->sec - 1;
+      diff->usec = end->usec + 1000000 - start->usec;
+   }
+   else {
+      diff->sec = end->sec - start->sec;
+      diff->usec = end->usec - start->usec;
+   }
+}
+
+void osal_timer_start(osal_timert * self, uint32 timeout_usec)
+{
+   struct timeval start_time;
+   struct timeval timeout;
+   struct timeval stop_time;
+
+   osal_gettimeofday(&start_time, 0);
+   timeout.tv_sec = timeout_usec / USECS_PER_SEC;
+   timeout.tv_usec = timeout_usec % USECS_PER_SEC;
+   timeradd(&start_time, &timeout, &stop_time);
+
+   self->stop_time.sec = stop_time.tv_sec;
+   self->stop_time.usec = stop_time.tv_usec;
+}
+
+boolean osal_timer_is_expired (osal_timert * self)
+{
+   struct timeval current_time;
+   struct timeval stop_time;
+   int is_not_yet_expired;
+
+   osal_gettimeofday(&current_time, 0);
+   stop_time.tv_sec = self->stop_time.sec;
+   stop_time.tv_usec = self->stop_time.usec;
+   is_not_yet_expired = timercmp(&current_time, &stop_time, <);
+
+   return is_not_yet_expired == FALSE;
+}
+
+void *osal_malloc(size_t size)
+{
+   return malloc(size);
+}
+
+void osal_free(void *ptr)
+{
+   free(ptr);
+}
+
+int osal_thread_create(void *thandle, int stacksize, void *func, void *param)
+{
+   int                  ret;
+   pthread_attr_t       attr;
+   pthread_t            *threadp;
+
+   threadp = thandle;
+   pthread_attr_init(&attr);
+   pthread_attr_setstacksize(&attr, stacksize);
+   ret = pthread_create(threadp, &attr, func, param);
+   if(ret < 0)
+   {
+      return 0;
+   }
+   return 1;
+}
+
+int osal_thread_create_rt(void *thandle, int stacksize, void *func, void *param)
+{
+   int                  ret;
+   pthread_attr_t       attr;
+   struct sched_param   schparam;
+   pthread_t            *threadp;
+
+   threadp = thandle;
+   pthread_attr_init(&attr);
+   pthread_attr_setstacksize(&attr, stacksize);
+   ret = pthread_create(threadp, &attr, func, param);
+   pthread_attr_destroy(&attr);
+   if(ret < 0)
+   {
+      return 0;
+   }
+   memset(&schparam, 0, sizeof(schparam));
+   schparam.sched_priority = 40;
+   ret = pthread_setschedparam(*threadp, SCHED_FIFO, &schparam);
+   if(ret < 0)
+   {
+      return 0;
+   }
+
+   return 1;
+}

--- a/osal/win32/osal.c
+++ b/osal/win32/osal.c
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the GNU General Public License version 2 with exceptions. See
+ * LICENSE file in the project root for full license information
+ */
+
+#include <winsock2.h>
+#include <osal.h>
+#include "osal_win32.h"
+#include "Python.h"
+
+static int64_t sysfrequency;
+static double qpc2usec;
+
+#define USECS_PER_SEC     1000000
+
+int osal_getrelativetime(struct timeval *tv, struct timezone *tz)
+{
+   int64_t wintime, usecs;
+   if(!sysfrequency)
+   {
+      timeBeginPeriod(1);
+      QueryPerformanceFrequency((LARGE_INTEGER *)&sysfrequency);
+      qpc2usec = 1000000.0 / sysfrequency;
+   }
+   QueryPerformanceCounter((LARGE_INTEGER *)&wintime);
+   usecs = (int64_t)((double)wintime * qpc2usec);
+   tv->tv_sec = (long)(usecs / 1000000);
+   tv->tv_usec = (long)(usecs - (tv->tv_sec * 1000000));
+
+   return 1;
+}
+
+int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+   FILETIME system_time;
+   int64 system_time64, usecs;
+
+   /* The offset variable is required to switch from Windows epoch (January 1, 1601) to
+    * Unix epoch (January 1, 1970). Number of days between both epochs: 134.774
+    *
+    * The time returned by GetSystemTimeAsFileTime() changes in 100 ns steps, so the
+    * following factors are required for the conversion from days to 100 ns steps:
+    *
+    * 86.400 seconds per day; 1.000.000 microseconds per second; 10 * 100 ns per microsecond
+   */
+   int64 offset = -134774LL * 86400LL * 1000000LL * 10LL;
+
+   GetSystemTimeAsFileTime(&system_time);
+
+   system_time64 = ((int64)(system_time.dwHighDateTime) << 32) + (int64)system_time.dwLowDateTime;
+   system_time64 += offset;
+   usecs = system_time64 / 10;
+
+   tv->tv_sec = (long)(usecs / 1000000);
+   tv->tv_usec = (long)(usecs - (tv->tv_sec * 1000000));
+
+   return 1;
+}
+
+ec_timet osal_current_time (void)
+{
+   struct timeval current_time;
+   ec_timet return_value;
+
+   osal_gettimeofday (&current_time, 0);
+   return_value.sec = current_time.tv_sec;
+   return_value.usec = current_time.tv_usec;
+   return return_value;
+}
+
+void osal_time_diff(ec_timet *start, ec_timet *end, ec_timet *diff)
+{
+   if (end->usec < start->usec) {
+      diff->sec = end->sec - start->sec - 1;
+      diff->usec = end->usec + 1000000 - start->usec;
+   }
+   else {
+      diff->sec = end->sec - start->sec;
+      diff->usec = end->usec - start->usec;
+   }
+}
+
+void osal_timer_start (osal_timert *self, uint32 timeout_usec)
+{
+   struct timeval start_time;
+   struct timeval timeout;
+   struct timeval stop_time;
+
+   osal_getrelativetime (&start_time, 0);
+   timeout.tv_sec = timeout_usec / USECS_PER_SEC;
+   timeout.tv_usec = timeout_usec % USECS_PER_SEC;
+   timeradd (&start_time, &timeout, &stop_time);
+   self->stop_time.sec = stop_time.tv_sec;
+   self->stop_time.usec = stop_time.tv_usec;
+}
+
+boolean osal_timer_is_expired (osal_timert *self)
+{
+   struct timeval current_time;
+   struct timeval stop_time;
+   int is_not_yet_expired;
+
+   osal_getrelativetime (&current_time, 0);
+   stop_time.tv_sec = self->stop_time.sec;
+   stop_time.tv_usec = self->stop_time.usec;
+   is_not_yet_expired = timercmp (&current_time, &stop_time, <);
+
+   return is_not_yet_expired == FALSE;
+}
+
+int osal_usleep(uint32 usec)
+{
+   osal_timert qtime;
+   osal_timer_start(&qtime, usec);
+   Py_BEGIN_ALLOW_THREADS
+   if(usec >= 1000)
+   {
+      SleepEx(usec / 1000, FALSE);
+   }
+   while(!osal_timer_is_expired(&qtime));
+   Py_END_ALLOW_THREADS
+   return 1;
+}
+
+void *osal_malloc(size_t size)
+{
+   return malloc(size);
+}
+
+void osal_free(void *ptr)
+{
+   free(ptr);
+}
+
+int osal_thread_create(void **thandle, int stacksize, void *func, void *param)
+{
+   *thandle = CreateThread(NULL, stacksize, func, param, 0, NULL);
+   if(!thandle)
+   {
+      return 0;
+   }
+   return 1;
+}
+
+int osal_thread_create_rt(void **thandle, int stacksize, void *func, void *param)
+{
+   int ret;
+   ret = osal_thread_create(thandle, stacksize, func, param);
+   if (ret)
+   {
+      ret = SetThreadPriority(*thandle, THREAD_PRIORITY_TIME_CRITICAL);
+   }
+   return ret;
+}

--- a/oshw/linux/nicdrv.c
+++ b/oshw/linux/nicdrv.c
@@ -1,0 +1,648 @@
+/*
+ * Licensed under the GNU General Public License version 2 with exceptions. See
+ * LICENSE file in the project root for full license information
+ */
+
+/** \file
+ * \brief
+ * EtherCAT RAW socket driver.
+ *
+ * Low level interface functions to send and receive EtherCAT packets.
+ * EtherCAT has the property that packets are only send by the master,
+ * and the send packets always return in the receive buffer.
+ * There can be multiple packets "on the wire" before they return.
+ * To combine the received packets with the original send packets a buffer
+ * system is installed. The identifier is put in the index item of the
+ * EtherCAT header. The index is stored and compared when a frame is received.
+ * If there is a match the packet can be combined with the transmit packet
+ * and returned to the higher level function.
+ *
+ * The socket layer can exhibit a reversal in the packet order (rare).
+ * If the Tx order is A-B-C the return order could be A-C-B. The indexed buffer
+ * will reorder the packets automatically.
+ *
+ * The "redundant" option will configure two sockets and two NIC interfaces.
+ * Slaves are connected to both interfaces, one on the IN port and one on the
+ * OUT port. Packets are send via both interfaces. Any one of the connections
+ * (also an interconnect) can be removed and the slaves are still serviced with
+ * packets. The software layer will detect the possible failure modes and
+ * compensate. If needed the packets from interface A are resent through interface B.
+ * This layer if fully transparent for the higher layers.
+ */
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <time.h>
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+#include <netpacket/packet.h>
+#include <pthread.h>
+
+#include "oshw.h"
+#include "osal.h"
+#include "Python.h"
+
+/** Redundancy modes */
+enum
+{
+   /** No redundancy, single NIC mode */
+   ECT_RED_NONE,
+   /** Double redundant NIC connection */
+   ECT_RED_DOUBLE
+};
+
+
+/** Primary source MAC address used for EtherCAT.
+ * This address is not the MAC address used from the NIC.
+ * EtherCAT does not care about MAC addressing, but it is used here to
+ * differentiate the route the packet traverses through the EtherCAT
+ * segment. This is needed to find out the packet flow in redundant
+ * configurations. */
+const uint16 priMAC[3] = { 0x0101, 0x0101, 0x0101 };
+/** Secondary source MAC address used for EtherCAT. */
+const uint16 secMAC[3] = { 0x0404, 0x0404, 0x0404 };
+
+/** second MAC word is used for identification */
+#define RX_PRIM priMAC[1]
+/** second MAC word is used for identification */
+#define RX_SEC secMAC[1]
+
+static void ecx_clear_rxbufstat(int *rxbufstat)
+{
+   int i;
+   for(i = 0; i < EC_MAXBUF; i++)
+   {
+      rxbufstat[i] = EC_BUF_EMPTY;
+   }
+}
+
+/** Basic setup to connect NIC to socket.
+ * @param[in] port        = port context struct
+ * @param[in] ifname      = Name of NIC device, f.e. "eth0"
+ * @param[in] secondary   = if >0 then use secondary stack instead of primary
+ * @return >0 if succeeded
+ */
+int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
+{
+   int i;
+   int r, rval, ifindex;
+   struct timeval timeout;
+   struct ifreq ifr;
+   struct sockaddr_ll sll;
+   int *psock;
+   pthread_mutexattr_t mutexattr;
+
+   rval = 0;
+   if (secondary)
+   {
+      /* secondary port struct available? */
+      if (port->redport)
+      {
+         /* when using secondary socket it is automatically a redundant setup */
+         psock = &(port->redport->sockhandle);
+         *psock = -1;
+         port->redstate                   = ECT_RED_DOUBLE;
+         port->redport->stack.sock        = &(port->redport->sockhandle);
+         port->redport->stack.txbuf       = &(port->txbuf);
+         port->redport->stack.txbuflength = &(port->txbuflength);
+         port->redport->stack.tempbuf     = &(port->redport->tempinbuf);
+         port->redport->stack.rxbuf       = &(port->redport->rxbuf);
+         port->redport->stack.rxbufstat   = &(port->redport->rxbufstat);
+         port->redport->stack.rxsa        = &(port->redport->rxsa);
+         ecx_clear_rxbufstat(&(port->redport->rxbufstat[0]));
+      }
+      else
+      {
+         /* fail */
+         return 0;
+      }
+   }
+   else
+   {
+      pthread_mutexattr_init(&mutexattr);
+      pthread_mutexattr_setprotocol(&mutexattr  , PTHREAD_PRIO_INHERIT);
+      pthread_mutex_init(&(port->getindex_mutex), &mutexattr);
+      pthread_mutex_init(&(port->tx_mutex)      , &mutexattr);
+      pthread_mutex_init(&(port->rx_mutex)      , &mutexattr);
+      port->sockhandle        = -1;
+      port->lastidx           = 0;
+      port->redstate          = ECT_RED_NONE;
+      port->stack.sock        = &(port->sockhandle);
+      port->stack.txbuf       = &(port->txbuf);
+      port->stack.txbuflength = &(port->txbuflength);
+      port->stack.tempbuf     = &(port->tempinbuf);
+      port->stack.rxbuf       = &(port->rxbuf);
+      port->stack.rxbufstat   = &(port->rxbufstat);
+      port->stack.rxsa        = &(port->rxsa);
+      ecx_clear_rxbufstat(&(port->rxbufstat[0]));
+      psock = &(port->sockhandle);
+   }
+   /* we use RAW packet socket, with packet type ETH_P_ECAT */
+   *psock = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ECAT));
+
+   timeout.tv_sec =  0;
+   timeout.tv_usec = 1;
+   r = setsockopt(*psock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+   r = setsockopt(*psock, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+   i = 1;
+   r = setsockopt(*psock, SOL_SOCKET, SO_DONTROUTE, &i, sizeof(i));
+   /* connect socket to NIC by name */
+   strcpy(ifr.ifr_name, ifname);
+   r = ioctl(*psock, SIOCGIFINDEX, &ifr);
+   ifindex = ifr.ifr_ifindex;
+   strcpy(ifr.ifr_name, ifname);
+   ifr.ifr_flags = 0;
+   /* reset flags of NIC interface */
+   r = ioctl(*psock, SIOCGIFFLAGS, &ifr);
+   /* set flags of NIC interface, here promiscuous and broadcast */
+   ifr.ifr_flags = ifr.ifr_flags | IFF_PROMISC | IFF_BROADCAST;
+   r = ioctl(*psock, SIOCSIFFLAGS, &ifr);
+   /* bind socket to protocol, in this case RAW EtherCAT */
+   sll.sll_family = AF_PACKET;
+   sll.sll_ifindex = ifindex;
+   sll.sll_protocol = htons(ETH_P_ECAT);
+   r = bind(*psock, (struct sockaddr *)&sll, sizeof(sll));
+   /* setup ethernet headers in tx buffers so we don't have to repeat it */
+   for (i = 0; i < EC_MAXBUF; i++)
+   {
+      ec_setupheader(&(port->txbuf[i]));
+      port->rxbufstat[i] = EC_BUF_EMPTY;
+   }
+   ec_setupheader(&(port->txbuf2));
+   if (r == 0) rval = 1;
+
+   return rval;
+}
+
+/** Close sockets used
+ * @param[in] port        = port context struct
+ * @return 0
+ */
+int ecx_closenic(ecx_portt *port)
+{
+   if (port->sockhandle >= 0)
+      close(port->sockhandle);
+   if ((port->redport) && (port->redport->sockhandle >= 0))
+      close(port->redport->sockhandle);
+
+   return 0;
+}
+
+/** Fill buffer with ethernet header structure.
+ * Destination MAC is always broadcast.
+ * Ethertype is always ETH_P_ECAT.
+ * @param[out] p = buffer
+ */
+void ec_setupheader(void *p)
+{
+   ec_etherheadert *bp;
+   bp = p;
+   bp->da0 = htons(0xffff);
+   bp->da1 = htons(0xffff);
+   bp->da2 = htons(0xffff);
+   bp->sa0 = htons(priMAC[0]);
+   bp->sa1 = htons(priMAC[1]);
+   bp->sa2 = htons(priMAC[2]);
+   bp->etype = htons(ETH_P_ECAT);
+}
+
+/** Get new frame identifier index and allocate corresponding rx buffer.
+ * @param[in] port        = port context struct
+ * @return new index.
+ */
+int ecx_getindex(ecx_portt *port)
+{
+   int idx;
+   int cnt;
+
+   pthread_mutex_lock( &(port->getindex_mutex) );
+
+   idx = port->lastidx + 1;
+   /* index can't be larger than buffer array */
+   if (idx >= EC_MAXBUF)
+   {
+      idx = 0;
+   }
+   cnt = 0;
+   /* try to find unused index */
+   while ((port->rxbufstat[idx] != EC_BUF_EMPTY) && (cnt < EC_MAXBUF))
+   {
+      idx++;
+      cnt++;
+      if (idx >= EC_MAXBUF)
+      {
+         idx = 0;
+      }
+   }
+   port->rxbufstat[idx] = EC_BUF_ALLOC;
+   if (port->redstate != ECT_RED_NONE)
+      port->redport->rxbufstat[idx] = EC_BUF_ALLOC;
+   port->lastidx = idx;
+
+   pthread_mutex_unlock( &(port->getindex_mutex) );
+
+   return idx;
+}
+
+/** Set rx buffer status.
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index in buffer array
+ * @param[in] bufstat  = status to set
+ */
+void ecx_setbufstat(ecx_portt *port, int idx, int bufstat)
+{
+   port->rxbufstat[idx] = bufstat;
+   if (port->redstate != ECT_RED_NONE)
+      port->redport->rxbufstat[idx] = bufstat;
+}
+
+/** Transmit buffer over socket (non blocking).
+ * @param[in] port        = port context struct
+ * @param[in] idx         = index in tx buffer array
+ * @param[in] stacknumber  = 0=Primary 1=Secondary stack
+ * @return socket send result
+ */
+int ecx_outframe(ecx_portt *port, int idx, int stacknumber)
+{
+   int lp, rval;
+   ec_stackT *stack;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   lp = (*stack->txbuflength)[idx];
+   (*stack->rxbufstat)[idx] = EC_BUF_TX;
+   rval = send(*stack->sock, (*stack->txbuf)[idx], lp, 0);
+   if (rval == -1)
+   {
+      (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
+   }
+
+   return rval;
+}
+
+/** Transmit buffer over socket (non blocking).
+ * @param[in] port        = port context struct
+ * @param[in] idx = index in tx buffer array
+ * @return socket send result
+ */
+int ecx_outframe_red(ecx_portt *port, int idx)
+{
+   ec_comt *datagramP;
+   ec_etherheadert *ehp;
+   int rval;
+
+   ehp = (ec_etherheadert *)&(port->txbuf[idx]);
+   /* rewrite MAC source address 1 to primary */
+   ehp->sa1 = htons(priMAC[1]);
+   /* transmit over primary socket*/
+   rval = ecx_outframe(port, idx, 0);
+   if (port->redstate != ECT_RED_NONE)
+   {
+      pthread_mutex_lock( &(port->tx_mutex) );
+      ehp = (ec_etherheadert *)&(port->txbuf2);
+      /* use dummy frame for secondary socket transmit (BRD) */
+      datagramP = (ec_comt*)&(port->txbuf2[ETH_HEADERSIZE]);
+      /* write index to frame */
+      datagramP->index = idx;
+      /* rewrite MAC source address 1 to secondary */
+      ehp->sa1 = htons(secMAC[1]);
+      /* transmit over secondary socket */
+      port->redport->rxbufstat[idx] = EC_BUF_TX;
+      if (send(port->redport->sockhandle, &(port->txbuf2), port->txbuflength2 , 0) == -1)
+      {
+         port->redport->rxbufstat[idx] = EC_BUF_EMPTY;
+      }
+      pthread_mutex_unlock( &(port->tx_mutex) );
+   }
+
+   return rval;
+}
+
+/** Non blocking read of socket. Put frame in temporary buffer.
+ * @param[in] port        = port context struct
+ * @param[in] stacknumber = 0=primary 1=secondary stack
+ * @return >0 if frame is available and read
+ */
+static int ecx_recvpkt(ecx_portt *port, int stacknumber)
+{
+   int lp, bytesrx;
+   ec_stackT *stack;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   lp = sizeof(port->tempinbuf);
+   bytesrx = recv(*stack->sock, (*stack->tempbuf), lp, 0);
+   port->tempinbufs = bytesrx;
+
+   return (bytesrx > 0);
+}
+
+/** Non blocking receive frame function. Uses RX buffer and index to combine
+ * read frame with transmitted frame. To compensate for received frames that
+ * are out-of-order all frames are stored in their respective indexed buffer.
+ * If a frame was placed in the buffer previously, the function retrieves it
+ * from that buffer index without calling ec_recvpkt. If the requested index
+ * is not already in the buffer it calls ec_recvpkt to fetch it. There are
+ * three options now, 1 no frame read, so exit. 2 frame read but other
+ * than requested index, store in buffer and exit. 3 frame read with matching
+ * index, store in buffer, set completed flag in buffer status and exit.
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx         = requested index of frame
+ * @param[in] stacknumber = 0=primary 1=secondary stack
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME or EC_OTHERFRAME.
+ */
+int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
+{
+   uint16  l;
+   int     rval;
+   int     idxf;
+   ec_etherheadert *ehp;
+   ec_comt *ecp;
+   ec_stackT *stack;
+   ec_bufT *rxbuf;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   rval = EC_NOFRAME;
+   rxbuf = &(*stack->rxbuf)[idx];
+   /* check if requested index is already in buffer ? */
+   if ((idx < EC_MAXBUF) && ((*stack->rxbufstat)[idx] == EC_BUF_RCVD))
+   {
+      l = (*rxbuf)[0] + ((uint16)((*rxbuf)[1] & 0x0f) << 8);
+      /* return WKC */
+      rval = ((*rxbuf)[l] + ((uint16)(*rxbuf)[l + 1] << 8));
+      /* mark as completed */
+      (*stack->rxbufstat)[idx] = EC_BUF_COMPLETE;
+   }
+   else
+   {
+      pthread_mutex_lock(&(port->rx_mutex));
+      /* non blocking call to retrieve frame from socket */
+      if (ecx_recvpkt(port, stacknumber))
+      {
+         rval = EC_OTHERFRAME;
+         ehp =(ec_etherheadert*)(stack->tempbuf);
+         /* check if it is an EtherCAT frame */
+         if (ehp->etype == htons(ETH_P_ECAT))
+         {
+            ecp =(ec_comt*)(&(*stack->tempbuf)[ETH_HEADERSIZE]);
+            l = etohs(ecp->elength) & 0x0fff;
+            idxf = ecp->index;
+            /* found index equals requested index ? */
+            if (idxf == idx)
+            {
+               /* yes, put it in the buffer array (strip ethernet header) */
+               memcpy(rxbuf, &(*stack->tempbuf)[ETH_HEADERSIZE], (*stack->txbuflength)[idx] - ETH_HEADERSIZE);
+               /* return WKC */
+               rval = ((*rxbuf)[l] + ((uint16)((*rxbuf)[l + 1]) << 8));
+               /* mark as completed */
+               (*stack->rxbufstat)[idx] = EC_BUF_COMPLETE;
+               /* store MAC source word 1 for redundant routing info */
+               (*stack->rxsa)[idx] = ntohs(ehp->sa1);
+            }
+            else
+            {
+               /* check if index exist and someone is waiting for it */
+               if (idxf < EC_MAXBUF && (*stack->rxbufstat)[idxf] == EC_BUF_TX)
+               {
+                  rxbuf = &(*stack->rxbuf)[idxf];
+                  /* put it in the buffer array (strip ethernet header) */
+                  memcpy(rxbuf, &(*stack->tempbuf)[ETH_HEADERSIZE], (*stack->txbuflength)[idxf] - ETH_HEADERSIZE);
+                  /* mark as received */
+                  (*stack->rxbufstat)[idxf] = EC_BUF_RCVD;
+                  (*stack->rxsa)[idxf] = ntohs(ehp->sa1);
+               }
+               else
+               {
+                  /* strange things happened */
+               }
+            }
+         }
+      }
+      pthread_mutex_unlock( &(port->rx_mutex) );
+
+   }
+
+   /* WKC if matching frame found */
+   return rval;
+}
+
+/** Blocking redundant receive frame function. If redundant mode is not active then
+ * it skips the secondary stack and redundancy functions. In redundant mode it waits
+ * for both (primary and secondary) frames to come in. The result goes in an decision
+ * tree that decides, depending on the route of the packet and its possible missing arrival,
+ * how to reroute the original packet to get the data in an other try.
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx = requested index of frame
+ * @param[in] timer = absolute timeout time
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME.
+ */
+static int ecx_waitinframe_red(ecx_portt *port, int idx, osal_timert *timer)
+{
+   osal_timert timer2;
+   int wkc  = EC_NOFRAME;
+   int wkc2 = EC_NOFRAME;
+   int primrx, secrx;
+   Py_BEGIN_ALLOW_THREADS
+
+   /* if not in redundant mode then always assume secondary is OK */
+   if (port->redstate == ECT_RED_NONE)
+      wkc2 = 0;
+   do
+   {
+      /* only read frame if not already in */
+      if (wkc <= EC_NOFRAME)
+         wkc  = ecx_inframe(port, idx, 0);
+      /* only try secondary if in redundant mode */
+      if (port->redstate != ECT_RED_NONE)
+      {
+         /* only read frame if not already in */
+         if (wkc2 <= EC_NOFRAME)
+            wkc2 = ecx_inframe(port, idx, 1);
+      }
+   /* wait for both frames to arrive or timeout */
+   } while (((wkc <= EC_NOFRAME) || (wkc2 <= EC_NOFRAME)) && !osal_timer_is_expired(timer));
+   /* only do redundant functions when in redundant mode */
+   if (port->redstate != ECT_RED_NONE)
+   {
+      /* primrx if the received MAC source on primary socket */
+      primrx = 0;
+      if (wkc > EC_NOFRAME) primrx = port->rxsa[idx];
+      /* secrx if the received MAC source on psecondary socket */
+      secrx = 0;
+      if (wkc2 > EC_NOFRAME) secrx = port->redport->rxsa[idx];
+
+      /* primary socket got secondary frame and secondary socket got primary frame */
+      /* normal situation in redundant mode */
+      if ( ((primrx == RX_SEC) && (secrx == RX_PRIM)) )
+      {
+         /* copy secondary buffer to primary */
+         memcpy(&(port->rxbuf[idx]), &(port->redport->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+         wkc = wkc2;
+      }
+      /* primary socket got nothing or primary frame, and secondary socket got secondary frame */
+      /* we need to resend TX packet */
+      if ( ((primrx == 0) && (secrx == RX_SEC)) ||
+           ((primrx == RX_PRIM) && (secrx == RX_SEC)) )
+      {
+         /* If both primary and secondary have partial connection retransmit the primary received
+          * frame over the secondary socket. The result from the secondary received frame is a combined
+          * frame that traversed all slaves in standard order. */
+         if ( (primrx == RX_PRIM) && (secrx == RX_SEC) )
+         {
+            /* copy primary rx to tx buffer */
+            memcpy(&(port->txbuf[idx][ETH_HEADERSIZE]), &(port->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+         }
+         osal_timer_start (&timer2, EC_TIMEOUTRET);
+         /* resend secondary tx */
+         ecx_outframe(port, idx, 1);
+         do
+         {
+            /* retrieve frame */
+            wkc2 = ecx_inframe(port, idx, 1);
+         } while ((wkc2 <= EC_NOFRAME) && !osal_timer_is_expired(&timer2));
+         if (wkc2 > EC_NOFRAME)
+         {
+            /* copy secondary result to primary rx buffer */
+            memcpy(&(port->rxbuf[idx]), &(port->redport->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+            wkc = wkc2;
+         }
+      }
+   }
+   Py_END_ALLOW_THREADS
+
+   /* return WKC or EC_NOFRAME */
+   return wkc;
+}
+
+/** Blocking receive frame function. Calls ec_waitinframe_red().
+ * @param[in] port        = port context struct
+ * @param[in] idx       = requested index of frame
+ * @param[in] timeout   = timeout in us
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME.
+ */
+int ecx_waitinframe(ecx_portt *port, int idx, int timeout)
+{
+   int wkc;
+   osal_timert timer;
+
+   osal_timer_start (&timer, timeout);
+   wkc = ecx_waitinframe_red(port, idx, &timer);
+
+   return wkc;
+}
+
+/** Blocking send and receive frame function. Used for non processdata frames.
+ * A datagram is build into a frame and transmitted via this function. It waits
+ * for an answer and returns the workcounter. The function retries if time is
+ * left and the result is WKC=0 or no frame received.
+ *
+ * The function calls ec_outframe_red() and ec_waitinframe_red().
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index of frame
+ * @param[in] timeout  = timeout in us
+ * @return Workcounter or EC_NOFRAME
+ */
+int ecx_srconfirm(ecx_portt *port, int idx, int timeout)
+{
+   int wkc = EC_NOFRAME;
+   osal_timert timer1, timer2;
+
+   osal_timer_start (&timer1, timeout);
+   do
+   {
+      /* tx frame on primary and if in redundant mode a dummy on secondary */
+      ecx_outframe_red(port, idx);
+      if (timeout < EC_TIMEOUTRET)
+      {
+         osal_timer_start (&timer2, timeout);
+      }
+      else
+      {
+         /* normally use partial timeout for rx */
+         osal_timer_start (&timer2, EC_TIMEOUTRET);
+      }
+      /* get frame from primary or if in redundant mode possibly from secondary */
+      wkc = ecx_waitinframe_red(port, idx, &timer2);
+   /* wait for answer with WKC>=0 or otherwise retry until timeout */
+   } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired (&timer1));
+
+   return wkc;
+}
+
+#ifdef EC_VER1
+int ec_setupnic(const char *ifname, int secondary)
+{
+   return ecx_setupnic(&ecx_port, ifname, secondary);
+}
+
+int ec_closenic(void)
+{
+   return ecx_closenic(&ecx_port);
+}
+
+int ec_getindex(void)
+{
+   return ecx_getindex(&ecx_port);
+}
+
+void ec_setbufstat(int idx, int bufstat)
+{
+   ecx_setbufstat(&ecx_port, idx, bufstat);
+}
+
+int ec_outframe(int idx, int stacknumber)
+{
+   return ecx_outframe(&ecx_port, idx, stacknumber);
+}
+
+int ec_outframe_red(int idx)
+{
+   return ecx_outframe_red(&ecx_port, idx);
+}
+
+int ec_inframe(int idx, int stacknumber)
+{
+   return ecx_inframe(&ecx_port, idx, stacknumber);
+}
+
+int ec_waitinframe(int idx, int timeout)
+{
+   return ecx_waitinframe(&ecx_port, idx, timeout);
+}
+
+int ec_srconfirm(int idx, int timeout)
+{
+   return ecx_srconfirm(&ecx_port, idx, timeout);
+}
+#endif

--- a/oshw/macosx/nicdrv.c
+++ b/oshw/macosx/nicdrv.c
@@ -1,0 +1,653 @@
+﻿/*
+ * Licensed under the GNU General Public License version 2 with exceptions. See
+ * LICENSE file in the project root for full license information
+ */
+
+/** \file
+ * \brief
+ * EtherCAT RAW socket driver.
+ *
+ * Low level interface functions to send and receive EtherCAT packets.
+ * EtherCAT has the property that packets are only send by the master,
+ * and the send packets always return in the receive buffer.
+ * There can be multiple packets "on the wire" before they return.
+ * To combine the received packets with the original send packets a buffer
+ * system is installed. The identifier is put in the index item of the
+ * EtherCAT header. The index is stored and compared when a frame is received.
+ * If there is a match the packet can be combined with the transmit packet
+ * and returned to the higher level function.
+ *
+ * The socket layer can exhibit a reversal in the packet order (rare).
+ * If the Tx order is A-B-C the return order could be A-C-B. The indexed buffer
+ * will reorder the packets automatically.
+ *
+ * The "redundant" option will configure two sockets and two NIC interfaces.
+ * Slaves are connected to both interfaces, one on the IN port and one on the
+ * OUT port. Packets are send via both interfaces. Any one of the connections
+ * (also an interconnect) can be removed and the slaves are still serviced with
+ * packets. The software layer will detect the possible failure modes and
+ * compensate. If needed the packets from interface A are resent through interface B.
+ * This layer is fully transparent for the higher layers.
+ */
+
+
+#include <assert.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+
+#include "ethercattype.h"
+#include "nicdrv.h"
+#include "osal.h"
+#include "Python.h"
+
+/** Redundancy modes */
+enum
+{
+    /** No redundancy, single NIC mode */
+    ECT_RED_NONE,
+    /** Double redundant NIC connection */
+    ECT_RED_DOUBLE
+};
+
+/** Primary source MAC address used for EtherCAT.
+ * This address is not the MAC address used from the NIC.
+ * EtherCAT does not care about MAC addressing, but it is used here to
+ * differentiate the route the packet traverses through the EtherCAT
+ * segment. This is needed to fund out the packet flow in redundant
+ * configurations. */
+const uint16 priMAC[3] = { 0x0101, 0x0101, 0x0101 };
+/** Secondary source MAC address used for EtherCAT. */
+const uint16 secMAC[3] = { 0x0404, 0x0404, 0x0404 };
+
+/** second MAC word is used for identification */
+#define RX_PRIM priMAC[1]
+/** second MAC word is used for identification */
+#define RX_SEC secMAC[1]
+
+static char errbuf[PCAP_ERRBUF_SIZE];
+
+static void ecx_clear_rxbufstat(int *rxbufstat)
+{
+   int i;
+   for(i = 0; i < EC_MAXBUF; i++)
+   {
+      rxbufstat[i] = EC_BUF_EMPTY;
+   }
+}
+
+/** Basic setup to connect NIC to socket.
+ * @param[in] port        = port context struct
+ * @param[in] ifname       = Name of NIC device, f.e. "eth0"
+ * @param[in] secondary      = if >0 then use secondary stack instead of primary
+ * @return >0 if succeeded
+ */
+int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
+{
+   int i, rval;
+   pcap_t **psock;
+
+   rval = 0;
+   if (secondary)
+   {
+      /* secondary port struct available? */
+      if (port->redport)
+      {
+         /* when using secondary socket it is automatically a redundant setup */
+         psock = &(port->redport->sockhandle);
+         *psock = NULL;
+         port->redstate                   = ECT_RED_DOUBLE;
+         port->redport->stack.sock        = &(port->redport->sockhandle);
+         port->redport->stack.txbuf       = &(port->txbuf);
+         port->redport->stack.txbuflength = &(port->txbuflength);
+         port->redport->stack.tempbuf     = &(port->redport->tempinbuf);
+         port->redport->stack.rxbuf       = &(port->redport->rxbuf);
+         port->redport->stack.rxbufstat   = &(port->redport->rxbufstat);
+         port->redport->stack.rxsa        = &(port->redport->rxsa);
+         ecx_clear_rxbufstat(&(port->redport->rxbufstat[0]));
+      }
+      else
+      {
+         /* fail */
+         return 0;
+      }
+   }
+   else
+   {
+      pthread_mutex_init(&(port->getindex_mutex), NULL);
+      pthread_mutex_init(&(port->tx_mutex), NULL);
+      pthread_mutex_init(&(port->rx_mutex), NULL);
+      port->sockhandle        = NULL;
+      port->lastidx           = 0;
+      port->redstate          = ECT_RED_NONE;
+      port->stack.sock        = &(port->sockhandle);
+      port->stack.txbuf       = &(port->txbuf);
+      port->stack.txbuflength = &(port->txbuflength);
+      port->stack.tempbuf     = &(port->tempinbuf);
+      port->stack.rxbuf       = &(port->rxbuf);
+      port->stack.rxbufstat   = &(port->rxbufstat);
+      port->stack.rxsa        = &(port->rxsa);
+      ecx_clear_rxbufstat(&(port->rxbufstat[0]));
+      psock = &(port->sockhandle);
+   }
+   *psock = pcap_open_live(ifname, 65536, 1, 0, errbuf);
+   if (NULL == *psock)
+   {
+      return 0;
+   }
+   rval = pcap_setdirection(*psock, PCAP_D_IN);
+   if (rval != 0)
+   {
+      return 0;
+   }
+   rval = pcap_setnonblock(*psock, 1, errbuf);
+   if (rval != 0)
+   {
+       return 0;
+   }
+
+   for (i = 0; i < EC_MAXBUF; i++)
+   {
+      ec_setupheader(&(port->txbuf[i]));
+      port->rxbufstat[i] = EC_BUF_EMPTY;
+   }
+   ec_setupheader(&(port->txbuf2));
+
+   return 1;
+}
+
+/** Close sockets used
+ * @param[in] port        = port context struct
+ * @return 0
+ */
+int ecx_closenic(ecx_portt *port)
+{
+   if (port->sockhandle != NULL)
+   {
+      pthread_mutex_destroy(&(port->getindex_mutex));
+      pthread_mutex_destroy(&(port->tx_mutex));
+      pthread_mutex_destroy(&(port->rx_mutex));
+      pcap_close(port->sockhandle);
+      port->sockhandle = NULL;
+   }
+   if ((port->redport) && (port->redport->sockhandle != NULL))
+   {
+      pcap_close(port->redport->sockhandle);
+      port->redport->sockhandle = NULL;
+   }
+
+   return 0;
+}
+
+/** Fill buffer with ethernet header structure.
+ * Destination MAC is always broadcast.
+ * Ethertype is always ETH_P_ECAT.
+ * @param[out] p = buffer
+ */
+void ec_setupheader(void *p)
+{
+   ec_etherheadert *bp;
+   bp = p;
+   bp->da0 = htons(0xffff);
+   bp->da1 = htons(0xffff);
+   bp->da2 = htons(0xffff);
+   bp->sa0 = htons(priMAC[0]);
+   bp->sa1 = htons(priMAC[1]);
+   bp->sa2 = htons(priMAC[2]);
+   bp->etype = htons(ETH_P_ECAT);
+}
+
+/** Get new frame identifier index and allocate corresponding rx buffer.
+ * @param[in] port        = port context struct
+ * @return new index.
+ */
+int ecx_getindex(ecx_portt *port)
+{
+   int idx;
+   int cnt;
+
+   pthread_mutex_lock(&(port->getindex_mutex));
+
+   idx = port->lastidx + 1;
+   /* index can't be larger than buffer array */
+   if (idx >= EC_MAXBUF)
+   {
+      idx = 0;
+   }
+   cnt = 0;
+   /* try to find unused index */
+   while ((port->rxbufstat[idx] != EC_BUF_EMPTY) && (cnt < EC_MAXBUF))
+   {
+      idx++;
+      cnt++;
+      if (idx >= EC_MAXBUF)
+      {
+         idx = 0;
+      }
+   }
+   port->rxbufstat[idx] = EC_BUF_ALLOC;
+   if (port->redstate != ECT_RED_NONE)
+      port->redport->rxbufstat[idx] = EC_BUF_ALLOC;
+   port->lastidx = idx;
+
+   pthread_mutex_unlock(&(port->getindex_mutex));
+
+   return idx;
+}
+
+/** Set rx buffer status.
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index in buffer array
+ * @param[in] bufstat   = status to set
+ */
+void ecx_setbufstat(ecx_portt *port, int idx, int bufstat)
+{
+   port->rxbufstat[idx] = bufstat;
+   if (port->redstate != ECT_RED_NONE)
+      port->redport->rxbufstat[idx] = bufstat;
+}
+
+/** Transmit buffer over socket (non blocking).
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index in tx buffer array
+ * @param[in] stacknumber   = 0=Primary 1=Secondary stack
+ * @return socket send result
+ */
+int ecx_outframe(ecx_portt *port, int idx, int stacknumber)
+{
+   int lp, rval;
+   ec_stackT *stack;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   lp = (*stack->txbuflength)[idx];
+   (*stack->rxbufstat)[idx] = EC_BUF_TX;
+   rval = pcap_sendpacket(*stack->sock, (*stack->txbuf)[idx], lp);
+   if (rval == PCAP_ERROR)
+   {
+      (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
+   }
+
+   return rval;
+}
+
+/** Transmit buffer over socket (non blocking).
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index in tx buffer array
+ * @return socket send result
+ */
+int ecx_outframe_red(ecx_portt *port, int idx)
+{
+   ec_comt *datagramP;
+   ec_etherheadert *ehp;
+   int rval;
+
+   ehp = (ec_etherheadert *)&(port->txbuf[idx]);
+   /* rewrite MAC source address 1 to primary */
+   ehp->sa1 = htons(priMAC[1]);
+   /* transmit over primary socket*/
+   rval = ecx_outframe(port, idx, 0);
+   if (port->redstate != ECT_RED_NONE)
+   {
+      pthread_mutex_lock( &(port->tx_mutex) );
+      ehp = (ec_etherheadert *)&(port->txbuf2);
+      /* use dummy frame for secondary socket transmit (BRD) */
+      datagramP = (ec_comt*)&(port->txbuf2[ETH_HEADERSIZE]);
+      /* write index to frame */
+      datagramP->index = idx;
+      /* rewrite MAC source address 1 to secondary */
+      ehp->sa1 = htons(secMAC[1]);
+      /* transmit over secondary socket */
+      port->redport->rxbufstat[idx] = EC_BUF_TX;
+      if (pcap_sendpacket(port->redport->sockhandle, (u_char const *)&(port->txbuf2), port->txbuflength2) == PCAP_ERROR)
+      {
+         port->redport->rxbufstat[idx] = EC_BUF_EMPTY;
+      }
+      pthread_mutex_unlock( &(port->tx_mutex) );
+   }
+
+   return rval;
+}
+
+/** Non blocking read of socket. Put frame in temporary buffer.
+ * @param[in] port        = port context struct
+ * @param[in] stacknumber = 0=primary 1=secondary stack
+ * @return >0 if frame is available and read
+ */
+static int ecx_recvpkt(ecx_portt *port, int stacknumber)
+{
+   int lp, bytesrx;
+   ec_stackT *stack;
+   struct pcap_pkthdr * header;
+   unsigned char const * pkt_data;
+   int res;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   lp = sizeof(port->tempinbuf);
+
+   res = pcap_next_ex(*stack->sock, &header, &pkt_data);
+   if (res <=0 )
+   {
+      port->tempinbufs = 0;
+      return 0;
+   }
+
+   bytesrx = header->len;
+   if (bytesrx > lp)
+   {
+      bytesrx = lp;
+   }
+   memcpy(*stack->tempbuf, pkt_data, bytesrx);
+   port->tempinbufs = bytesrx;
+   return (bytesrx > 0);
+}
+
+/** Non blocking receive frame function. Uses RX buffer and index to combine
+ * read frame with transmitted frame. To compensate for received frames that
+ * are out-of-order all frames are stored in their respective indexed buffer.
+ * If a frame was placed in the buffer previously, the function retrieves it
+ * from that buffer index without calling ec_recvpkt. If the requested index
+ * is not already in the buffer it calls ec_recvpkt to fetch it. There are
+ * three options now, 1 no frame read, so exit. 2 frame read but other
+ * than requested index, store in buffer and exit. 3 frame read with matching
+ * index, store in buffer, set completed flag in buffer status and exit.
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx         = requested index of frame
+ * @param[in] stacknumber  = 0=primary 1=secondary stack
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME or EC_OTHERFRAME.
+ */
+int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
+{
+   uint16  l;
+   int     rval;
+   int     idxf;
+   ec_etherheadert *ehp;
+   ec_comt *ecp;
+   ec_stackT *stack;
+   ec_bufT *rxbuf;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   rval = EC_NOFRAME;
+   rxbuf = &(*stack->rxbuf)[idx];
+   /* check if requested index is already in buffer ? */
+   if ((idx < EC_MAXBUF) && ((*stack->rxbufstat)[idx] == EC_BUF_RCVD))
+   {
+      l = (*rxbuf)[0] + ((uint16)((*rxbuf)[1] & 0x0f) << 8);
+      /* return WKC */
+      rval = ((*rxbuf)[l] + ((uint16)(*rxbuf)[l + 1] << 8));
+      /* mark as completed */
+      (*stack->rxbufstat)[idx] = EC_BUF_COMPLETE;
+   }
+   else
+   {
+      pthread_mutex_lock(&(port->rx_mutex));
+      /* non blocking call to retrieve frame from socket */
+      if (ecx_recvpkt(port, stacknumber))
+      {
+         rval = EC_OTHERFRAME;
+         ehp =(ec_etherheadert*)(stack->tempbuf);
+         /* check if it is an EtherCAT frame */
+         if (ehp->etype == htons(ETH_P_ECAT))
+         {
+            ecp =(ec_comt*)(&(*stack->tempbuf)[ETH_HEADERSIZE]);
+            l = etohs(ecp->elength) & 0x0fff;
+            idxf = ecp->index;
+            /* found index equals requested index ? */
+            if (idxf == idx)
+            {
+               /* yes, put it in the buffer array (strip ethernet header) */
+               memcpy(rxbuf, &(*stack->tempbuf)[ETH_HEADERSIZE], (*stack->txbuflength)[idx] - ETH_HEADERSIZE);
+               /* return WKC */
+               rval = ((*rxbuf)[l] + ((uint16)((*rxbuf)[l + 1]) << 8));
+               /* mark as completed */
+               (*stack->rxbufstat)[idx] = EC_BUF_COMPLETE;
+               /* store MAC source word 1 for redundant routing info */
+               (*stack->rxsa)[idx] = ntohs(ehp->sa1);
+            }
+            else
+            {
+               /* check if index exist and someone is waiting for it */
+               if (idxf < EC_MAXBUF && (*stack->rxbufstat)[idxf] == EC_BUF_TX)
+               {
+                  rxbuf = &(*stack->rxbuf)[idxf];
+                  /* put it in the buffer array (strip ethernet header) */
+                  memcpy(rxbuf, &(*stack->tempbuf)[ETH_HEADERSIZE], (*stack->txbuflength)[idxf] - ETH_HEADERSIZE);
+                  /* mark as received */
+                  (*stack->rxbufstat)[idxf] = EC_BUF_RCVD;
+                  (*stack->rxsa)[idxf] = ntohs(ehp->sa1);
+               }
+               else
+               {
+		          assert(0);
+                  /* strange things happened */
+               }
+            }
+         }
+      }
+      pthread_mutex_unlock( &(port->rx_mutex) );
+
+   }
+
+   /* WKC if matching frame found */
+   return rval;
+}
+
+/** Blocking redundant receive frame function. If redundant mode is not active then
+ * it skips the secondary stack and redundancy functions. In redundant mode it waits
+ * for both (primary and secondary) frames to come in. The result goes in an decision
+ * tree that decides, depending on the route of the packet and its possible missing arrival,
+ * how to reroute the original packet to get the data in an other try.
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx = requested index of frame
+ * @param[in] tvs = timeout
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME.
+ */
+static int ecx_waitinframe_red(ecx_portt *port, int idx, osal_timert *timer)
+{
+   osal_timert timer2;
+   int wkc  = EC_NOFRAME;
+   int wkc2 = EC_NOFRAME;
+   int primrx, secrx;
+   Py_BEGIN_ALLOW_THREADS
+
+   /* if not in redundant mode then always assume secondary is OK */
+   if (port->redstate == ECT_RED_NONE)
+      wkc2 = 0;
+   do
+   {
+      /* only read frame if not already in */
+      if (wkc <= EC_NOFRAME)
+         wkc  = ecx_inframe(port, idx, 0);
+      /* only try secondary if in redundant mode */
+      if (port->redstate != ECT_RED_NONE)
+      {
+         /* only read frame if not already in */
+         if (wkc2 <= EC_NOFRAME)
+            wkc2 = ecx_inframe(port, idx, 1);
+      }
+   /* wait for both frames to arrive or timeout */
+   } while (((wkc <= EC_NOFRAME) || (wkc2 <= EC_NOFRAME)) && !osal_timer_is_expired(timer));
+   /* only do redundant functions when in redundant mode */
+   if (port->redstate != ECT_RED_NONE)
+   {
+      /* primrx if the received MAC source on primary socket */
+      primrx = 0;
+      if (wkc > EC_NOFRAME) primrx = port->rxsa[idx];
+      /* secrx if the received MAC source on psecondary socket */
+      secrx = 0;
+      if (wkc2 > EC_NOFRAME) secrx = port->redport->rxsa[idx];
+
+      /* primary socket got secondary frame and secondary socket got primary frame */
+      /* normal situation in redundant mode */
+      if ( ((primrx == RX_SEC) && (secrx == RX_PRIM)) )
+      {
+         /* copy secondary buffer to primary */
+         memcpy(&(port->rxbuf[idx]), &(port->redport->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+         wkc = wkc2;
+      }
+      /* primary socket got nothing or primary frame, and secondary socket got secondary frame */
+      /* we need to resend TX packet */
+      if ( ((primrx == 0) && (secrx == RX_SEC)) ||
+           ((primrx == RX_PRIM) && (secrx == RX_SEC)) )
+      {
+         /* If both primary and secondary have partial connection retransmit the primary received
+          * frame over the secondary socket. The result from the secondary received frame is a combined
+          * frame that traversed all slaves in standard order. */
+         if ( (primrx == RX_PRIM) && (secrx == RX_SEC) )
+         {
+            /* copy primary rx to tx buffer */
+            memcpy(&(port->txbuf[idx][ETH_HEADERSIZE]), &(port->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+         }
+         osal_timer_start (&timer2, EC_TIMEOUTRET);
+         /* resend secondary tx */
+         ecx_outframe(port, idx, 1);
+         do
+         {
+            /* retrieve frame */
+            wkc2 = ecx_inframe(port, idx, 1);
+         } while ((wkc2 <= EC_NOFRAME) && !osal_timer_is_expired(&timer2));
+         if (wkc2 > EC_NOFRAME)
+         {
+            /* copy secondary result to primary rx buffer */
+            memcpy(&(port->rxbuf[idx]), &(port->redport->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+            wkc = wkc2;
+         }
+      }
+   }
+   Py_END_ALLOW_THREADS
+
+   /* return WKC or EC_NOFRAME */
+   return wkc;
+}
+
+/** Blocking receive frame function. Calls ec_waitinframe_red().
+ * @param[in] port        = port context struct
+ * @param[in] idx = requested index of frame
+ * @param[in] timeout = timeout in us
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME.
+ */
+int ecx_waitinframe(ecx_portt *port, int idx, int timeout)
+{
+   int wkc;
+   osal_timert timer;
+
+   osal_timer_start (&timer, timeout);
+   wkc = ecx_waitinframe_red(port, idx, &timer);
+
+   return wkc;
+}
+
+/** Blocking send and receive frame function. Used for non processdata frames.
+ * A datagram is build into a frame and transmitted via this function. It waits
+ * for an answer and returns the workcounter. The function retries if time is
+ * left and the result is WKC=0 or no frame received.
+ *
+ * The function calls ec_outframe_red() and ec_waitinframe_red().
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index of frame
+ * @param[in] timeout  = timeout in us
+ * @return Workcounter or EC_NOFRAME
+ */
+int ecx_srconfirm(ecx_portt *port, int idx, int timeout)
+{
+   int wkc = EC_NOFRAME;
+   osal_timert timer1, timer2;
+
+   osal_timer_start (&timer1, timeout);
+   do
+   {
+      /* tx frame on primary and if in redundant mode a dummy on secondary */
+      ecx_outframe_red(port, idx);
+      if (timeout < EC_TIMEOUTRET)
+      {
+         osal_timer_start (&timer2, timeout);
+      }
+      else
+      {
+         /* normally use partial timeout for rx */
+         osal_timer_start (&timer2, EC_TIMEOUTRET);
+      }
+      /* get frame from primary or if in redundant mode possibly from secondary */
+      wkc = ecx_waitinframe_red(port, idx, &timer2);
+   /* wait for answer with WKC>=0 or otherwise retry until timeout */
+   } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired (&timer1));
+
+   return wkc;
+}
+
+
+#ifdef EC_VER1
+
+int ec_setupnic(const char *ifname, int secondary)
+{
+   return ecx_setupnic(&ecx_port, ifname, secondary);
+}
+
+int ec_closenic(void)
+{
+   return ecx_closenic(&ecx_port);
+}
+
+int ec_getindex(void)
+{
+   return ecx_getindex(&ecx_port);
+}
+
+void ec_setbufstat(int idx, int bufstat)
+{
+   ecx_setbufstat(&ecx_port, idx, bufstat);
+}
+
+int ec_outframe(int idx, int stacknumber)
+{
+   return ecx_outframe(&ecx_port, idx, stacknumber);
+}
+
+int ec_outframe_red(int idx)
+{
+   return ecx_outframe_red(&ecx_port, idx);
+}
+
+int ec_inframe(int idx, int stacknumber)
+{
+   return ecx_inframe(&ecx_port, idx, stacknumber);
+}
+
+int ec_waitinframe(int idx, int timeout)
+{
+   return ecx_waitinframe(&ecx_port, idx, timeout);
+}
+
+int ec_srconfirm(int idx, int timeout)
+{
+   return ecx_srconfirm(&ecx_port, idx, timeout);
+}
+
+#endif

--- a/oshw/win32/nicdrv.c
+++ b/oshw/win32/nicdrv.c
@@ -1,0 +1,652 @@
+﻿/*
+ * Licensed under the GNU General Public License version 2 with exceptions. See
+ * LICENSE file in the project root for full license information
+ */
+
+/** \file
+ * \brief
+ * EtherCAT RAW socket driver.
+ *
+ * Low level interface functions to send and receive EtherCAT packets.
+ * EtherCAT has the property that packets are only send by the master,
+ * and the send packets always return in the receive buffer.
+ * There can be multiple packets "on the wire" before they return.
+ * To combine the received packets with the original send packets a buffer
+ * system is installed. The identifier is put in the index item of the
+ * EtherCAT header. The index is stored and compared when a frame is received.
+ * If there is a match the packet can be combined with the transmit packet
+ * and returned to the higher level function.
+ *
+ * The socket layer can exhibit a reversal in the packet order (rare).
+ * If the Tx order is A-B-C the return order could be A-C-B. The indexed buffer
+ * will reorder the packets automatically.
+ *
+ * The "redundant" option will configure two sockets and two NIC interfaces.
+ * Slaves are connected to both interfaces, one on the IN port and one on the
+ * OUT port. Packets are send via both interfaces. Any one of the connections
+ * (also an interconnect) can be removed and the slaves are still serviced with
+ * packets. The software layer will detect the possible failure modes and
+ * compensate. If needed the packets from interface A are resent through interface B.
+ * This layer is fully transparent for the higher layers.
+ */
+
+#ifdef WIN32
+
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+
+#include <winsock2.h>
+#include "ethercattype.h"
+#include <Mmsystem.h>
+#include "nicdrv.h"
+#include "osal_win32.h"
+#include "Python.h"
+
+#endif
+
+/** Redundancy modes */
+enum
+{
+    /** No redundancy, single NIC mode */
+    ECT_RED_NONE,
+    /** Double redundant NIC connection */
+    ECT_RED_DOUBLE
+};
+
+/** Primary source MAC address used for EtherCAT.
+ * This address is not the MAC address used from the NIC.
+ * EtherCAT does not care about MAC addressing, but it is used here to
+ * differentiate the route the packet traverses through the EtherCAT
+ * segment. This is needed to fund out the packet flow in redundant
+ * configurations. */
+const uint16 priMAC[3] = { 0x0101, 0x0101, 0x0101 };
+/** Secondary source MAC address used for EtherCAT. */
+const uint16 secMAC[3] = { 0x0404, 0x0404, 0x0404 };
+
+/** second MAC word is used for identification */
+#define RX_PRIM priMAC[1]
+/** second MAC word is used for identification */
+#define RX_SEC secMAC[1]
+
+static char errbuf[PCAP_ERRBUF_SIZE];
+
+static void ecx_clear_rxbufstat(int *rxbufstat)
+{
+   int i;
+   for(i = 0; i < EC_MAXBUF; i++)
+   {
+      rxbufstat[i] = EC_BUF_EMPTY;
+   }
+}
+
+/** Basic setup to connect NIC to socket.
+ * @param[in] port        = port context struct
+ * @param[in] ifname       = Name of NIC device, f.e. "eth0"
+ * @param[in] secondary      = if >0 then use secondary stack instead of primary
+ * @return >0 if succeeded
+ */
+int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
+{
+   int i, rval;
+   pcap_t **psock;
+
+   rval = 0;
+   if (secondary)
+   {
+      /* secondary port struct available? */
+      if (port->redport)
+      {
+         /* when using secondary socket it is automatically a redundant setup */
+         psock = &(port->redport->sockhandle);
+         *psock = NULL;
+         port->redstate                   = ECT_RED_DOUBLE;
+         port->redport->stack.sock        = &(port->redport->sockhandle);
+         port->redport->stack.txbuf       = &(port->txbuf);
+         port->redport->stack.txbuflength = &(port->txbuflength);
+         port->redport->stack.tempbuf     = &(port->redport->tempinbuf);
+         port->redport->stack.rxbuf       = &(port->redport->rxbuf);
+         port->redport->stack.rxbufstat   = &(port->redport->rxbufstat);
+         port->redport->stack.rxsa        = &(port->redport->rxsa);
+         ecx_clear_rxbufstat(&(port->redport->rxbufstat[0]));
+      }
+      else
+      {
+         /* fail */
+         return 0;
+      }
+   }
+   else
+   {
+      InitializeCriticalSection(&(port->getindex_mutex));
+      InitializeCriticalSection(&(port->tx_mutex));
+      InitializeCriticalSection(&(port->rx_mutex));
+      port->sockhandle        = NULL;
+      port->lastidx           = 0;
+      port->redstate          = ECT_RED_NONE;
+      port->stack.sock        = &(port->sockhandle);
+      port->stack.txbuf       = &(port->txbuf);
+      port->stack.txbuflength = &(port->txbuflength);
+      port->stack.tempbuf     = &(port->tempinbuf);
+      port->stack.rxbuf       = &(port->rxbuf);
+      port->stack.rxbufstat   = &(port->rxbufstat);
+      port->stack.rxsa        = &(port->rxsa);
+      ecx_clear_rxbufstat(&(port->rxbufstat[0]));
+      psock = &(port->sockhandle);
+   }
+   /* we use pcap socket to send RAW packets in windows user mode*/
+   *psock = pcap_open(ifname, 65536, PCAP_OPENFLAG_PROMISCUOUS |
+                                     PCAP_OPENFLAG_MAX_RESPONSIVENESS |
+                                     PCAP_OPENFLAG_NOCAPTURE_LOCAL, -1, NULL , errbuf);
+   if (NULL == *psock)
+   {
+      printf("interface %s could not open with pcap\n", ifname);
+      return 0;
+   }
+
+    for (i = 0; i < EC_MAXBUF; i++)
+   {
+      ec_setupheader(&(port->txbuf[i]));
+      port->rxbufstat[i] = EC_BUF_EMPTY;
+   }
+   ec_setupheader(&(port->txbuf2));
+
+   return 1;
+}
+
+/** Close sockets used
+ * @param[in] port        = port context struct
+ * @return 0
+ */
+int ecx_closenic(ecx_portt *port)
+{
+   timeEndPeriod(15);
+
+   if (port->sockhandle != NULL)
+   {
+      DeleteCriticalSection(&(port->getindex_mutex));
+      DeleteCriticalSection(&(port->tx_mutex));
+      DeleteCriticalSection(&(port->rx_mutex));
+      pcap_close(port->sockhandle);
+      port->sockhandle = NULL;
+   }
+   if ((port->redport) && (port->redport->sockhandle != NULL))
+   {
+      pcap_close(port->redport->sockhandle);
+      port->redport->sockhandle = NULL;
+   }
+
+   return 0;
+}
+
+/** Fill buffer with ethernet header structure.
+ * Destination MAC is always broadcast.
+ * Ethertype is always ETH_P_ECAT.
+ * @param[out] p = buffer
+ */
+void ec_setupheader(void *p)
+{
+   ec_etherheadert *bp;
+   bp = p;
+   bp->da0 = htons(0xffff);
+   bp->da1 = htons(0xffff);
+   bp->da2 = htons(0xffff);
+   bp->sa0 = htons(priMAC[0]);
+   bp->sa1 = htons(priMAC[1]);
+   bp->sa2 = htons(priMAC[2]);
+   bp->etype = htons(ETH_P_ECAT);
+}
+
+/** Get new frame identifier index and allocate corresponding rx buffer.
+ * @param[in] port        = port context struct
+ * @return new index.
+ */
+int ecx_getindex(ecx_portt *port)
+{
+   int idx;
+   int cnt;
+
+   EnterCriticalSection(&(port->getindex_mutex));
+
+   idx = port->lastidx + 1;
+   /* index can't be larger than buffer array */
+   if (idx >= EC_MAXBUF)
+   {
+      idx = 0;
+   }
+   cnt = 0;
+   /* try to find unused index */
+   while ((port->rxbufstat[idx] != EC_BUF_EMPTY) && (cnt < EC_MAXBUF))
+   {
+      idx++;
+      cnt++;
+      if (idx >= EC_MAXBUF)
+      {
+         idx = 0;
+      }
+   }
+   port->rxbufstat[idx] = EC_BUF_ALLOC;
+   if (port->redstate != ECT_RED_NONE)
+      port->redport->rxbufstat[idx] = EC_BUF_ALLOC;
+   port->lastidx = idx;
+
+   LeaveCriticalSection(&(port->getindex_mutex));
+
+   return idx;
+}
+
+/** Set rx buffer status.
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index in buffer array
+ * @param[in] bufstat   = status to set
+ */
+void ecx_setbufstat(ecx_portt *port, int idx, int bufstat)
+{
+   port->rxbufstat[idx] = bufstat;
+   if (port->redstate != ECT_RED_NONE)
+      port->redport->rxbufstat[idx] = bufstat;
+}
+
+/** Transmit buffer over socket (non blocking).
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index in tx buffer array
+ * @param[in] stacknumber   = 0=Primary 1=Secondary stack
+ * @return socket send result
+ */
+int ecx_outframe(ecx_portt *port, int idx, int stacknumber)
+{
+   int lp, rval;
+   ec_stackT *stack;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   lp = (*stack->txbuflength)[idx];
+   (*stack->rxbufstat)[idx] = EC_BUF_TX;
+   rval = pcap_sendpacket(*stack->sock, (*stack->txbuf)[idx], lp);
+   if (rval == PCAP_ERROR)
+   {
+      (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
+   }
+
+   return rval;
+}
+
+/** Transmit buffer over socket (non blocking).
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index in tx buffer array
+ * @return socket send result
+ */
+int ecx_outframe_red(ecx_portt *port, int idx)
+{
+   ec_comt *datagramP;
+   ec_etherheadert *ehp;
+   int rval;
+
+   ehp = (ec_etherheadert *)&(port->txbuf[idx]);
+   /* rewrite MAC source address 1 to primary */
+   ehp->sa1 = htons(priMAC[1]);
+   /* transmit over primary socket*/
+   rval = ecx_outframe(port, idx, 0);
+   if (port->redstate != ECT_RED_NONE)
+   {
+      EnterCriticalSection( &(port->tx_mutex) );
+      ehp = (ec_etherheadert *)&(port->txbuf2);
+      /* use dummy frame for secondary socket transmit (BRD) */
+      datagramP = (ec_comt*)&(port->txbuf2[ETH_HEADERSIZE]);
+      /* write index to frame */
+      datagramP->index = idx;
+      /* rewrite MAC source address 1 to secondary */
+      ehp->sa1 = htons(secMAC[1]);
+      /* transmit over secondary socket */
+      port->redport->rxbufstat[idx] = EC_BUF_TX;
+      if (pcap_sendpacket(port->redport->sockhandle, (u_char const *)&(port->txbuf2), port->txbuflength2) == PCAP_ERROR)
+      {
+         port->redport->rxbufstat[idx] = EC_BUF_EMPTY;
+      }
+      LeaveCriticalSection( &(port->tx_mutex) );
+   }
+
+   return rval;
+}
+
+/** Non blocking read of socket. Put frame in temporary buffer.
+ * @param[in] port        = port context struct
+ * @param[in] stacknumber = 0=primary 1=secondary stack
+ * @return >0 if frame is available and read
+ */
+static int ecx_recvpkt(ecx_portt *port, int stacknumber)
+{
+   int lp, bytesrx;
+   ec_stackT *stack;
+   struct pcap_pkthdr * header;
+   unsigned char const * pkt_data;
+   int res;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   lp = sizeof(port->tempinbuf);
+
+   res = pcap_next_ex(*stack->sock, &header, &pkt_data);
+   if (res <=0 )
+   {
+     port->tempinbufs = 0;
+      return 0;
+   }
+   bytesrx = header->len;
+   if (bytesrx > lp)
+   {
+      bytesrx = lp;
+   }
+   memcpy(*stack->tempbuf, pkt_data, bytesrx);
+   port->tempinbufs = bytesrx;
+   return (bytesrx > 0);
+}
+
+/** Non blocking receive frame function. Uses RX buffer and index to combine
+ * read frame with transmitted frame. To compensate for received frames that
+ * are out-of-order all frames are stored in their respective indexed buffer.
+ * If a frame was placed in the buffer previously, the function retrieves it
+ * from that buffer index without calling ec_recvpkt. If the requested index
+ * is not already in the buffer it calls ec_recvpkt to fetch it. There are
+ * three options now, 1 no frame read, so exit. 2 frame read but other
+ * than requested index, store in buffer and exit. 3 frame read with matching
+ * index, store in buffer, set completed flag in buffer status and exit.
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx         = requested index of frame
+ * @param[in] stacknumber  = 0=primary 1=secondary stack
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME or EC_OTHERFRAME.
+ */
+int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
+{
+   uint16  l;
+   int     rval;
+   int     idxf;
+   ec_etherheadert *ehp;
+   ec_comt *ecp;
+   ec_stackT *stack;
+   ec_bufT *rxbuf;
+
+   if (!stacknumber)
+   {
+      stack = &(port->stack);
+   }
+   else
+   {
+      stack = &(port->redport->stack);
+   }
+   rval = EC_NOFRAME;
+   rxbuf = &(*stack->rxbuf)[idx];
+   /* check if requested index is already in buffer ? */
+   if ((idx < EC_MAXBUF) && ((*stack->rxbufstat)[idx] == EC_BUF_RCVD))
+   {
+      l = (*rxbuf)[0] + ((uint16)((*rxbuf)[1] & 0x0f) << 8);
+      /* return WKC */
+      rval = ((*rxbuf)[l] + ((uint16)(*rxbuf)[l + 1] << 8));
+      /* mark as completed */
+      (*stack->rxbufstat)[idx] = EC_BUF_COMPLETE;
+   }
+   else
+   {
+      EnterCriticalSection(&(port->rx_mutex));
+      /* non blocking call to retrieve frame from socket */
+      if (ecx_recvpkt(port, stacknumber))
+      {
+         rval = EC_OTHERFRAME;
+         ehp =(ec_etherheadert*)(stack->tempbuf);
+         /* check if it is an EtherCAT frame */
+         if (ehp->etype == htons(ETH_P_ECAT))
+         {
+            ecp =(ec_comt*)(&(*stack->tempbuf)[ETH_HEADERSIZE]);
+            l = etohs(ecp->elength) & 0x0fff;
+            idxf = ecp->index;
+            /* found index equals requested index ? */
+            if (idxf == idx)
+            {
+               /* yes, put it in the buffer array (strip ethernet header) */
+               memcpy(rxbuf, &(*stack->tempbuf)[ETH_HEADERSIZE], (*stack->txbuflength)[idx] - ETH_HEADERSIZE);
+               /* return WKC */
+               rval = ((*rxbuf)[l] + ((uint16)((*rxbuf)[l + 1]) << 8));
+               /* mark as completed */
+               (*stack->rxbufstat)[idx] = EC_BUF_COMPLETE;
+               /* store MAC source word 1 for redundant routing info */
+               (*stack->rxsa)[idx] = ntohs(ehp->sa1);
+            }
+            else
+            {
+               /* check if index exist and someone is waiting for it */
+               if (idxf < EC_MAXBUF && (*stack->rxbufstat)[idxf] == EC_BUF_TX)
+               {
+                  rxbuf = &(*stack->rxbuf)[idxf];
+                  /* put it in the buffer array (strip ethernet header) */
+                  memcpy(rxbuf, &(*stack->tempbuf)[ETH_HEADERSIZE], (*stack->txbuflength)[idxf] - ETH_HEADERSIZE);
+                  /* mark as received */
+                  (*stack->rxbufstat)[idxf] = EC_BUF_RCVD;
+                  (*stack->rxsa)[idxf] = ntohs(ehp->sa1);
+               }
+               else
+               {
+                  /* strange things happened */
+               }
+            }
+         }
+      }
+      LeaveCriticalSection( &(port->rx_mutex) );
+
+   }
+
+   /* WKC if matching frame found */
+   return rval;
+}
+
+/** Blocking redundant receive frame function. If redundant mode is not active then
+ * it skips the secondary stack and redundancy functions. In redundant mode it waits
+ * for both (primary and secondary) frames to come in. The result goes in an decision
+ * tree that decides, depending on the route of the packet and its possible missing arrival,
+ * how to reroute the original packet to get the data in an other try.
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx = requested index of frame
+ * @param[in] tvs = timeout
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME.
+ */
+static int ecx_waitinframe_red(ecx_portt *port, int idx, osal_timert *timer)
+{
+
+   osal_timert timer2;
+   int wkc  = EC_NOFRAME;
+   int wkc2 = EC_NOFRAME;
+   int primrx, secrx;
+   Py_BEGIN_ALLOW_THREADS
+
+   /* if not in redundant mode then always assume secondary is OK */
+   if (port->redstate == ECT_RED_NONE)
+      wkc2 = 0;
+   do
+   {
+      /* only read frame if not already in */
+      if (wkc <= EC_NOFRAME)
+         wkc  = ecx_inframe(port, idx, 0);
+      /* only try secondary if in redundant mode */
+      if (port->redstate != ECT_RED_NONE)
+      {
+         /* only read frame if not already in */
+         if (wkc2 <= EC_NOFRAME)
+            wkc2 = ecx_inframe(port, idx, 1);
+      }
+   /* wait for both frames to arrive or timeout */
+   } while (((wkc <= EC_NOFRAME) || (wkc2 <= EC_NOFRAME)) && !osal_timer_is_expired(timer));
+   /* only do redundant functions when in redundant mode */
+   if (port->redstate != ECT_RED_NONE)
+   {
+      /* primrx if the received MAC source on primary socket */
+      primrx = 0;
+      if (wkc > EC_NOFRAME) primrx = port->rxsa[idx];
+      /* secrx if the received MAC source on psecondary socket */
+      secrx = 0;
+      if (wkc2 > EC_NOFRAME) secrx = port->redport->rxsa[idx];
+
+      /* primary socket got secondary frame and secondary socket got primary frame */
+      /* normal situation in redundant mode */
+      if ( ((primrx == RX_SEC) && (secrx == RX_PRIM)) )
+      {
+         /* copy secondary buffer to primary */
+         memcpy(&(port->rxbuf[idx]), &(port->redport->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+         wkc = wkc2;
+      }
+      /* primary socket got nothing or primary frame, and secondary socket got secondary frame */
+      /* we need to resend TX packet */
+      if ( ((primrx == 0) && (secrx == RX_SEC)) ||
+           ((primrx == RX_PRIM) && (secrx == RX_SEC)) )
+      {
+         /* If both primary and secondary have partial connection retransmit the primary received
+          * frame over the secondary socket. The result from the secondary received frame is a combined
+          * frame that traversed all slaves in standard order. */
+         if ( (primrx == RX_PRIM) && (secrx == RX_SEC) )
+         {
+            /* copy primary rx to tx buffer */
+            memcpy(&(port->txbuf[idx][ETH_HEADERSIZE]), &(port->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+         }
+         osal_timer_start (&timer2, EC_TIMEOUTRET);
+         /* resend secondary tx */
+         ecx_outframe(port, idx, 1);
+         do
+         {
+            /* retrieve frame */
+            wkc2 = ecx_inframe(port, idx, 1);
+         } while ((wkc2 <= EC_NOFRAME) && !osal_timer_is_expired(&timer2));
+         if (wkc2 > EC_NOFRAME)
+         {
+            /* copy secondary result to primary rx buffer */
+            memcpy(&(port->rxbuf[idx]), &(port->redport->rxbuf[idx]), port->txbuflength[idx] - ETH_HEADERSIZE);
+            wkc = wkc2;
+         }
+      }
+   }
+   Py_END_ALLOW_THREADS
+   /* return WKC or EC_NOFRAME */
+   return wkc;
+}
+
+/** Blocking receive frame function. Calls ec_waitinframe_red().
+ * @param[in] port        = port context struct
+ * @param[in] idx = requested index of frame
+ * @param[in] timeout = timeout in us
+ * @return Workcounter if a frame is found with corresponding index, otherwise
+ * EC_NOFRAME.
+ */
+int ecx_waitinframe(ecx_portt *port, int idx, int timeout)
+{
+   int wkc;
+   osal_timert timer;
+
+   osal_timer_start (&timer, timeout);
+   wkc = ecx_waitinframe_red(port, idx, &timer);
+
+   return wkc;
+}
+
+/** Blocking send and receive frame function. Used for non processdata frames.
+ * A datagram is build into a frame and transmitted via this function. It waits
+ * for an answer and returns the workcounter. The function retries if time is
+ * left and the result is WKC=0 or no frame received.
+ *
+ * The function calls ec_outframe_red() and ec_waitinframe_red().
+ *
+ * @param[in] port        = port context struct
+ * @param[in] idx      = index of frame
+ * @param[in] timeout  = timeout in us
+ * @return Workcounter or EC_NOFRAME
+ */
+int ecx_srconfirm(ecx_portt *port, int idx, int timeout)
+{
+   int wkc = EC_NOFRAME;
+   osal_timert timer1, timer2;
+
+   osal_timer_start (&timer1, timeout);
+   do
+   {
+      /* tx frame on primary and if in redundant mode a dummy on secondary */
+      ecx_outframe_red(port, idx);
+      if (timeout < EC_TIMEOUTRET)
+      {
+         osal_timer_start (&timer2, timeout);
+      }
+      else
+      {
+         /* normally use partial timeout for rx */
+         osal_timer_start (&timer2, EC_TIMEOUTRET);
+      }
+      /* get frame from primary or if in redundant mode possibly from secondary */
+      wkc = ecx_waitinframe_red(port, idx, &timer2);
+   /* wait for answer with WKC>=0 or otherwise retry until timeout */
+   } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired (&timer1));
+
+   return wkc;
+}
+
+
+#ifdef EC_VER1
+
+int ec_setupnic(const char *ifname, int secondary)
+{
+   return ecx_setupnic(&ecx_port, ifname, secondary);
+}
+
+int ec_closenic(void)
+{
+   return ecx_closenic(&ecx_port);
+}
+
+int ec_getindex(void)
+{
+   return ecx_getindex(&ecx_port);
+}
+
+void ec_setbufstat(int idx, int bufstat)
+{
+   ecx_setbufstat(&ecx_port, idx, bufstat);
+}
+
+int ec_outframe(int idx, int stacknumber)
+{
+   return ecx_outframe(&ecx_port, idx, stacknumber);
+}
+
+int ec_outframe_red(int idx)
+{
+   return ecx_outframe_red(&ecx_port, idx);
+}
+
+int ec_inframe(int idx, int stacknumber)
+{
+   return ecx_inframe(&ecx_port, idx, stacknumber);
+}
+
+int ec_waitinframe(int idx, int timeout)
+{
+   return ecx_waitinframe(&ecx_port, idx, timeout);
+}
+
+int ec_srconfirm(int idx, int timeout)
+{
+   return ecx_srconfirm(&ecx_port, idx, timeout);
+}
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ elif sys.platform.startswith('darwin'):
 
 soem_macros.append(('EC_VER2', ''))
 
-soem_sources.extend([os.path.join('.', 'soem', 'osal', os_name, 'osal.c'),
+soem_sources.extend([os.path.join('.', 'osal', os_name, 'osal.c'),
                      os.path.join('.', 'soem', 'oshw', os_name, 'oshw.c'),
-                     os.path.join('.', 'soem', 'oshw', os_name, 'nicdrv.c'),
+                     os.path.join('.', 'oshw', os_name, 'nicdrv.c'),
                      os.path.join('.', 'soem', 'soem', 'ethercatbase.c'),
                      os.path.join('.', 'soem', 'soem', 'ethercatcoe.c'),
                      os.path.join('.', 'soem', 'soem', 'ethercatconfig.c'),


### PR DESCRIPTION
In Python, when 2 or more threads are created they can't work in parallel because of [GIL](https://wiki.python.org/moin/GlobalInterpreterLock). Some functions in Python (such as sleep) allow running another thread during its execution. In PySOEM, sdo_read and sdo_write (for example) await the slave response, but this wait does not unblock Python threads.

This pull request solves this problem by modifying the osal.c and nicdrv.c files and unblock Python threads in the blocking functions, as osal_usleep.

### Tests
I made a manual test to verify SDO reads does not block the threads.
The test has a main thread and a secondary thread:

- The main thread makes a lot of SDO reads.
- Meanwhile, the secondary has a loop that saves the current timestamp and does a little sleep (5 ms).
- Finally, the list of timestamps saved is plotted.

The result of the new implementation:
![new_pysoem](https://github.com/bnjmnp/pysoem/assets/3721567/91ad788b-00df-4541-a487-7a200dfa3611)
The secondary thread is hardly affected by the SDO reads.

The result of the old implementation:
![old_pysoem](https://github.com/bnjmnp/pysoem/assets/3721567/89152aad-741a-44bb-80e3-8c029ddf8da3)
The secondary thread is very affected by the SDO reads. When the SDO reads loop ends, the secondary thread works like in the new implementation case.

#### Test code:

```python
import time
from threading import Thread

import pysoem
import matplotlib.pyplot as plt

THREAD_ITERATIONS = 40
READ_ITERATIONS = 100
interface_name = "\\Device\\NPF_{18CCD8AA-98F3-46F2-BE78-DAE9CC53D7BB}"
times = []


def show_plot(y_data):
    x_data = list(range(len(y_data)))
    last_point = len(y_data)-1
    middle_point = len(y_data)//2
    m = (y_data[last_point] - y_data[middle_point]) / \
        (x_data[last_point] - x_data[middle_point])
    b = (y_data[last_point] - m * x_data[last_point])
    # Calculates the lineal equation with the last point and the middle point

    fig, ax = plt.subplots()
    ax.plot(x_data, y_data, 'o')
    ax.plot([0, x_data[last_point]], [b, y_data[last_point]],
            label=f"y={m:.4f}x+{b:.4f}")
    ax.set(xlabel='N', ylabel='time (s)')
    ax.legend()
    ax.grid()
    plt.show()


def thread_func():
    for _ in range(THREAD_ITERATIONS):
        times.append(time.time())
        time.sleep(0.005)


master = pysoem.Master()
master.open(interface_name)
master.config_init()
slave = master.slaves[0]
thread_instance = Thread(target=thread_func)
thread_instance.start()
for _ in range(READ_ITERATIONS):
    status_word = slave.sdo_read(0x2011, 0)
thread_instance.join()
times_with_0 = [(x - times[0]) for x in times]
show_plot(times_with_0)
```
