### PR TITLE
Fix paths in MANIFEST.in for sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include LICENSE
 include README.rst
 include examples/*.py
-include pysoem/cpysoem.pxd
-include pysoem/pysoem.pyx
-include pysoem/pysoem.c
+include src/pysoem/cpysoem.pxd
+include src/pysoem/pysoem.pyx
+include src/pysoem/pysoem.c
 recursive-include soem *.h *.c


### PR DESCRIPTION
Looks like it was missed to change the file paths in MANIFEST.in in be74f0c2.
This breaks all sdist installations.

Fixes #155 

Please consider publishing a new release after merging.