### PR TITLE
Build wheels for arm64

### DIFF
--- a/.github/workflows/manual_triggerd_build_and_upload_to_test_pypi.yml
+++ b/.github/workflows/manual_triggerd_build_and_upload_to_test_pypi.yml
@@ -17,8 +17,17 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.21.1
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and aarch64 emulated
+          CIBW_ARCHS_LINUX: auto aarch64
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release_triggerd_build_and_upload_to_pypi.yml
+++ b/.github/workflows/release_triggerd_build_and_upload_to_pypi.yml
@@ -19,8 +19,17 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.21.1
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and aarch64 emulated
+          CIBW_ARCHS_LINUX: auto aarch64
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This should allow the CI to build wheels for arm64. However, I didn't find an easy way to test this, so no idea if it actually works.

Instructions were taken from https://cibuildwheel.pypa.io/en/stable/faq/#emulation

Arm64 keeps getting more and more popular and sometimes those embedded systems are not equipped to support an sdist install. It would also make things easier on e.g. a Raspberry Pi.