### PR TITLE
expose soem timeouts to python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,15 @@ soem_sources.extend([os.path.join('.', 'soem', 'osal', os_name, 'osal.c'),
                      os.path.join('.', 'soem', 'soem', 'ethercatfoe.c'),
                      os.path.join('.', 'soem', 'soem', 'ethercatmain.c'),
                      os.path.join('.', 'soem', 'soem', 'ethercatprint.c'),
-                     os.path.join('.', 'soem', 'soem', 'ethercatsoe.c')])
+                     os.path.join('.', 'soem', 'soem', 'ethercatsoe.c'),
+                     os.path.join('.', 'src', 'soem', 'soem_config.c')])
 
 soem_inc_dirs.extend([os.path.join('.', 'soem', 'oshw', os_name),
                       os.path.join('.', 'soem', 'osal', os_name),
                       os.path.join('.', 'soem', 'oshw'),
                       os.path.join('.', 'soem', 'osal'),
-                      os.path.join('.', 'soem', 'soem')])
+                      os.path.join('.', 'soem', 'soem'),
+                      os.path.join('.', 'src', 'soem')])
 
 
 def readme():

--- a/src/pysoem/__init__.py
+++ b/src/pysoem/__init__.py
@@ -83,3 +83,8 @@ from pysoem.pysoem import (
     CdefSlave,
     CdefCoeObjectEntry,
 )
+
+# Timeouts:
+from pysoem.pysoem import (
+    TIMEOUTS
+)

--- a/src/pysoem/__init__.py
+++ b/src/pysoem/__init__.py
@@ -84,7 +84,7 @@ from pysoem.pysoem import (
     CdefCoeObjectEntry,
 )
 
-# Timeouts:
+# Settings:
 from pysoem.pysoem import (
-    TIMEOUTS
+    settings
 )

--- a/src/pysoem/cpysoem.pxd
+++ b/src/pysoem/cpysoem.pxd
@@ -86,7 +86,17 @@ cdef extern from "ethercat.h":
         uint8   b1
         uint16  w1
         uint16  w2
-    
+
+    # from soem_config.h
+    ctypedef struct Ttimeouts:
+        int ret
+        int safe
+        int eeprom
+        int tx_mailbox
+        int rx_mailbox
+        int state
+    extern Ttimeouts soem_timeouts;
+
     # from nicdrv.h
         
     ctypedef struct ec_stackT:

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -53,6 +53,64 @@ ECT_COEDET_PDOCONFIG = 0x08
 ECT_COEDET_UPLOAD    = 0x10
 ECT_COEDET_SDOCA     = 0x20
 
+cdef class _Timeouts:
+
+    cdef cpysoem.Ttimeouts* _t
+
+    def __cinit__(self):
+        self._t = &cpysoem.soem_timeouts
+
+    @property
+    def ret(self) -> int:
+        return self._t.ret
+
+    @ret.setter
+    def ret(self, value: int):
+        self._t.ret = value
+
+    @property
+    def safe(self) -> int:
+        return self._t.safe
+
+    @safe.setter
+    def safe(self, value: int):
+        self._t.safe = value
+
+    @property
+    def eeprom(self) -> int:
+        return self._t.eeprom
+
+    @eeprom.setter
+    def eeprom(self, value: int):
+        self._t.eeprom = value
+
+    @property
+    def tx_mailbox(self) -> int:
+        return self._t.tx_mailbox
+
+    @tx_mailbox.setter
+    def tx_mailbox(self, value: int):
+        self._t.tx_mailbox = value
+
+    @property
+    def rx_mailbox(self) -> int:
+        return self._t.rx_mailbox
+
+    @rx_mailbox.setter
+    def rx_mailbox(self, value: int):
+        self._t.rx_mailbox = value
+
+    @property
+    def state(self) -> int:
+        return self._t.state
+
+    @state.setter
+    def state(self, value: int):
+        self._t.state = value
+
+TIMEOUTS = _Timeouts()
+
+
 
 cpdef enum ec_datatype:
     ECT_BOOLEAN         = 0x0001,

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -53,7 +53,7 @@ ECT_COEDET_PDOCONFIG = 0x08
 ECT_COEDET_UPLOAD    = 0x10
 ECT_COEDET_SDOCA     = 0x20
 
-cdef class _Timeouts:
+cdef class CdefTimeouts:
 
     cdef cpysoem.Ttimeouts* _t
 
@@ -108,9 +108,14 @@ cdef class _Timeouts:
     def state(self, value: int):
         self._t.state = value
 
-TIMEOUTS = _Timeouts()
+cdef class CdefSettings:
 
+    cdef public CdefTimeouts timeouts
 
+    def __init__(self):
+        self.timeouts = CdefTimeouts()
+
+settings = CdefSettings()
 
 cpdef enum ec_datatype:
     ECT_BOOLEAN         = 0x0001,

--- a/src/soem/soem_config.c
+++ b/src/soem/soem_config.c
@@ -1,0 +1,11 @@
+#include "soem_config.h"
+
+/* Default timeouts in us */
+Ttimeouts soem_timeouts = {
+    .ret = 2000,
+    .safe = 20000,
+    .eeprom = 20000,
+    .tx_mailbox = 20000,
+    .rx_mailbox = 700000,
+    .state = 2000000
+};

--- a/src/soem/soem_config.h
+++ b/src/soem/soem_config.h
@@ -1,0 +1,30 @@
+#ifndef _SOEM_CONFIG_H
+#define _SOEM_CONFIG_H
+
+typedef struct {
+    int ret;
+    int safe;
+    int eeprom;
+    int tx_mailbox;
+    int rx_mailbox;
+    int state;
+} Ttimeouts;
+
+extern Ttimeouts soem_timeouts;
+
+/** timeout value in us for tx frame to return to rx */
+#define EC_TIMEOUTRET      soem_timeouts.ret
+/** timeout value in us for safe data transfer, max. triple retry */
+#define EC_TIMEOUTRET3     (EC_TIMEOUTRET * 3)
+/** timeout value in us for return "safe" variant (f.e. wireless) */
+#define EC_TIMEOUTSAFE     soem_timeouts.safe
+/** timeout value in us for EEPROM access */
+#define EC_TIMEOUTEEP      soem_timeouts.eeprom
+/** timeout value in us for tx mailbox cycle */
+#define EC_TIMEOUTTXM      soem_timeouts.tx_mailbox
+/** timeout value in us for rx mailbox cycle */
+#define EC_TIMEOUTRXM      soem_timeouts.rx_mailbox
+/** timeout value in us for check statechange */
+#define EC_TIMEOUTSTATE    soem_timeouts.state
+
+#endif /* _SOEM_CONFIG_H */

--- a/tests/pysoem_basic_test.py
+++ b/tests/pysoem_basic_test.py
@@ -105,3 +105,29 @@ def test_closed_interface_slave(ifname):
 
     with pytest.raises(pysoem.NetworkInterfaceNotOpenError) as exec_info:
         slaves[0].sdo_read(0x1018, 1)
+
+
+def test_tune_timeouts():
+    assert pysoem.TIMEOUTS.ret == 2_000
+    pysoem.TIMEOUTS.ret = 5_000
+    assert pysoem.TIMEOUTS.ret == 5_000
+
+    assert pysoem.TIMEOUTS.safe == 20_000
+    pysoem.TIMEOUTS.safe = 70_000
+    assert pysoem.TIMEOUTS.safe == 70_000
+
+    assert pysoem.TIMEOUTS.eeprom == 20_000
+    pysoem.TIMEOUTS.eeprom = 30_000
+    assert pysoem.TIMEOUTS.eeprom == 30_000
+
+    assert pysoem.TIMEOUTS.tx_mailbox == 20_000
+    pysoem.TIMEOUTS.tx_mailbox = 90_000
+    assert pysoem.TIMEOUTS.tx_mailbox == 90_000
+
+    assert pysoem.TIMEOUTS.rx_mailbox == 700_000
+    pysoem.TIMEOUTS.rx_mailbox = 900_000
+    assert pysoem.TIMEOUTS.rx_mailbox == 900_000
+
+    assert pysoem.TIMEOUTS.state == 2_000_000
+    pysoem.TIMEOUTS.state = 5_000_000
+    assert pysoem.TIMEOUTS.state == 5_000_000

--- a/tests/pysoem_basic_test.py
+++ b/tests/pysoem_basic_test.py
@@ -108,26 +108,26 @@ def test_closed_interface_slave(ifname):
 
 
 def test_tune_timeouts():
-    assert pysoem.TIMEOUTS.ret == 2_000
-    pysoem.TIMEOUTS.ret = 5_000
-    assert pysoem.TIMEOUTS.ret == 5_000
+    assert pysoem.settings.timeouts.ret == 2_000
+    pysoem.settings.timeouts.ret = 5_000
+    assert pysoem.settings.timeouts.ret == 5_000
 
-    assert pysoem.TIMEOUTS.safe == 20_000
-    pysoem.TIMEOUTS.safe = 70_000
-    assert pysoem.TIMEOUTS.safe == 70_000
+    assert pysoem.settings.timeouts.safe == 20_000
+    pysoem.settings.timeouts.safe = 70_000
+    assert pysoem.settings.timeouts.safe == 70_000
 
-    assert pysoem.TIMEOUTS.eeprom == 20_000
-    pysoem.TIMEOUTS.eeprom = 30_000
-    assert pysoem.TIMEOUTS.eeprom == 30_000
+    assert pysoem.settings.timeouts.eeprom == 20_000
+    pysoem.settings.timeouts.eeprom = 30_000
+    assert pysoem.settings.timeouts.eeprom == 30_000
 
-    assert pysoem.TIMEOUTS.tx_mailbox == 20_000
-    pysoem.TIMEOUTS.tx_mailbox = 90_000
-    assert pysoem.TIMEOUTS.tx_mailbox == 90_000
+    assert pysoem.settings.timeouts.tx_mailbox == 20_000
+    pysoem.settings.timeouts.tx_mailbox = 90_000
+    assert pysoem.settings.timeouts.tx_mailbox == 90_000
 
-    assert pysoem.TIMEOUTS.rx_mailbox == 700_000
-    pysoem.TIMEOUTS.rx_mailbox = 900_000
-    assert pysoem.TIMEOUTS.rx_mailbox == 900_000
+    assert pysoem.settings.timeouts.rx_mailbox == 700_000
+    pysoem.settings.timeouts.rx_mailbox = 900_000
+    assert pysoem.settings.timeouts.rx_mailbox == 900_000
 
-    assert pysoem.TIMEOUTS.state == 2_000_000
-    pysoem.TIMEOUTS.state = 5_000_000
-    assert pysoem.TIMEOUTS.state == 5_000_000
+    assert pysoem.settings.timeouts.state == 2_000_000
+    pysoem.settings.timeouts.state = 5_000_000
+    assert pysoem.settings.timeouts.state == 5_000_000


### PR DESCRIPTION
The timeouts of soem are compiled in the python module, and is currently not possible to run a ethercat script on some slow computers without re-compiling the module. This PR exposes the timeouts so that they remain the same, but users are able to configure them in run-time.

This works by changing the soem defines to references to a struct, that is also modifiable by python wrapper.
This change depends on this: https://github.com/bnjmnp/SOEM/pull/1
