### PR TITLE
No-GIL Support to Selected Functions

### DIFF
--- a/src/pysoem/cpysoem.pxd
+++ b/src/pysoem/cpysoem.pxd
@@ -329,7 +329,6 @@ cdef extern from "ethercat.h":
     int ecx_writestate(ecx_contextt *context, uint16 slave)
     uint16 ecx_statecheck(ecx_contextt *context, uint16 slave, uint16 reqstate, int timeout)
     
-    int ecx_send_processdata(ecx_contextt *context)
     int ecx_send_overlap_processdata(ecx_contextt *context)
     int ecx_receive_processdata(ecx_contextt *context, int timeout)
     
@@ -357,4 +356,5 @@ cdef extern from "ethercat.h":
     int ecx_FPRD(ecx_portt *port, uint16 ADP, uint16 ADO, uint16 length, void *data, int timeout)
 
 cdef extern from "ethercat.h" nogil:
+    int ecx_send_processdata(ecx_contextt *context)
     int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int psize, void *p, int timeout)

--- a/src/pysoem/cpysoem.pxd
+++ b/src/pysoem/cpysoem.pxd
@@ -346,8 +346,6 @@ cdef extern from "ethercat.h":
     uint32 ecx_readeeprom(ecx_contextt *context, uint16 slave, uint16 eeproma, int timeout)
     int ecx_writeeeprom(ecx_contextt *context, uint16 slave, uint16 eeproma, uint16 data, int timeout)
 
-    int ecx_FOEread(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int *psize, void *p, int timeout)
-
     int ecx_FPWR(ecx_portt *port, uint16 ADP, uint16 ADO, uint16 length, void *data, int timeout)
     int ecx_FPRD(ecx_portt *port, uint16 ADP, uint16 ADO, uint16 length, void *data, int timeout)
 
@@ -356,5 +354,6 @@ cdef extern from "ethercat.h" nogil:
     int ecx_send_processdata(ecx_contextt *context)
     int ecx_receive_processdata(ecx_contextt *context, int timeout)
     int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int psize, void *p, int timeout)
+    int ecx_FOEread(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int *psize, void *p, int timeout)
     int ecx_SDOread(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex, boolean CA, int *psize, void *p, int timeout)
     int ecx_SDOwrite(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex, boolean CA, int psize, void *p, int Timeout)

--- a/src/pysoem/cpysoem.pxd
+++ b/src/pysoem/cpysoem.pxd
@@ -320,7 +320,6 @@ cdef extern from "ethercat.h":
     int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
     int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
     int ecx_SDOread(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex, boolean CA, int *psize, void *p, int timeout)
-    int ecx_SDOwrite(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex, boolean CA, int psize, void *p, int Timeout)
     int ecx_readODlist(ecx_contextt *context, uint16 Slave, ec_ODlistt *pODlist)
     int ecx_readODdescription(ecx_contextt *context, uint16 Item, ec_ODlistt *pODlist)
     int ecx_readOE(ecx_contextt *context, uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist)
@@ -358,3 +357,4 @@ cdef extern from "ethercat.h" nogil:
     int ecx_send_processdata(ecx_contextt *context)
     int ecx_receive_processdata(ecx_contextt *context, int timeout)
     int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int psize, void *p, int timeout)
+    int ecx_SDOwrite(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex, boolean CA, int psize, void *p, int Timeout)

--- a/src/pysoem/cpysoem.pxd
+++ b/src/pysoem/cpysoem.pxd
@@ -319,7 +319,6 @@ cdef extern from "ethercat.h":
     int ecx_config_init(ecx_contextt *context, uint8 usetable)
     int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
     int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
-    int ecx_SDOread(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex, boolean CA, int *psize, void *p, int timeout)
     int ecx_readODlist(ecx_contextt *context, uint16 Slave, ec_ODlistt *pODlist)
     int ecx_readODdescription(ecx_contextt *context, uint16 Item, ec_ODlistt *pODlist)
     int ecx_readOE(ecx_contextt *context, uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist)
@@ -357,4 +356,5 @@ cdef extern from "ethercat.h" nogil:
     int ecx_send_processdata(ecx_contextt *context)
     int ecx_receive_processdata(ecx_contextt *context, int timeout)
     int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int psize, void *p, int timeout)
+    int ecx_SDOread(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex, boolean CA, int *psize, void *p, int timeout)
     int ecx_SDOwrite(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex, boolean CA, int psize, void *p, int Timeout)

--- a/src/pysoem/cpysoem.pxd
+++ b/src/pysoem/cpysoem.pxd
@@ -316,7 +316,6 @@ cdef extern from "ethercat.h":
     int ecx_init(ecx_contextt* context, char* ifname)
     int ecx_init_redundant(ecx_contextt *context, ecx_redportt *redport, const char *ifname, char *if2name)
     void ecx_close(ecx_contextt *context)
-    int ecx_config_init(ecx_contextt *context, uint8 usetable)
     int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
     int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
     int ecx_readODlist(ecx_contextt *context, uint16 Slave, ec_ODlistt *pODlist)
@@ -353,6 +352,7 @@ cdef extern from "ethercat.h":
     int ecx_FPRD(ecx_portt *port, uint16 ADP, uint16 ADO, uint16 length, void *data, int timeout)
 
 cdef extern from "ethercat.h" nogil:
+    int ecx_config_init(ecx_contextt *context, uint8 usetable)
     int ecx_send_processdata(ecx_contextt *context)
     int ecx_receive_processdata(ecx_contextt *context, int timeout)
     int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int psize, void *p, int timeout)

--- a/src/pysoem/cpysoem.pxd
+++ b/src/pysoem/cpysoem.pxd
@@ -352,7 +352,9 @@ cdef extern from "ethercat.h":
     int ecx_writeeeprom(ecx_contextt *context, uint16 slave, uint16 eeproma, uint16 data, int timeout)
 
     int ecx_FOEread(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int *psize, void *p, int timeout)
-    int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int psize, void *p, int timeout)
 
     int ecx_FPWR(ecx_portt *port, uint16 ADP, uint16 ADO, uint16 length, void *data, int timeout)
     int ecx_FPRD(ecx_portt *port, uint16 ADP, uint16 ADO, uint16 length, void *data, int timeout)
+
+cdef extern from "ethercat.h" nogil:
+    int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int psize, void *p, int timeout)

--- a/src/pysoem/cpysoem.pxd
+++ b/src/pysoem/cpysoem.pxd
@@ -330,7 +330,6 @@ cdef extern from "ethercat.h":
     uint16 ecx_statecheck(ecx_contextt *context, uint16 slave, uint16 reqstate, int timeout)
     
     int ecx_send_overlap_processdata(ecx_contextt *context)
-    int ecx_receive_processdata(ecx_contextt *context, int timeout)
     
     int ecx_recover_slave(ecx_contextt *context, uint16 slave, int timeout)
     int ecx_reconfig_slave(ecx_contextt *context, uint16 slave, int timeout)
@@ -357,4 +356,5 @@ cdef extern from "ethercat.h":
 
 cdef extern from "ethercat.h" nogil:
     int ecx_send_processdata(ecx_contextt *context)
+    int ecx_receive_processdata(ecx_contextt *context, int timeout)
     int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 password, int psize, void *p, int timeout)

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -332,7 +332,7 @@ cdef class CdefMaster:
         
         Args:
             usetable (bool): True when using configtable to init slaves, False otherwise.
-            release_gil (:obj:`bool`, optional): True to write releasing the GIL. Defaults to False.
+            release_gil (:obj:`bool`, optional): True to initialize the slaves releasing the GIL. Defaults to False.
         
         Returns:
             int: Working counter of slave discover datagram = number of slaves found, -1 when no slave is connected
@@ -493,7 +493,7 @@ cdef class CdefMaster:
         In order to recombine the slave response, a stack is used.
 
         Args:
-            release_gil (:obj:`bool`, optional): True to write releasing the GIL. Defaults to False.
+            release_gil (:obj:`bool`, optional): True to transmit processdata releasing the GIL. Defaults to False.
         
         Returns:
             int: >0 if processdata is transmitted, might only by 0 if config map is not configured properly
@@ -536,7 +536,7 @@ cdef class CdefMaster:
 
         Args:
             timeout (int): Timeout in us.
-            release_gil (:obj:`bool`, optional): True to write releasing the GIL. Defaults to False.
+            release_gil (:obj:`bool`, optional): True to receive processdata releasing the GIL. Defaults to False.
         Returns
             int: Working Counter
         """
@@ -837,7 +837,7 @@ cdef class CdefSlave:
             subindex (int): Subindex of the object.
             size (:obj:`int`, optional): The size of the reading buffer.
             ca (:obj:`bool`, optional): complete access.
-            release_gil (:obj:`bool`, optional): True to write releasing the GIL. Defaults to False.
+            release_gil (:obj:`bool`, optional): True to read a CoE object releasing the GIL. Defaults to False.
 
         Returns:
             bytes: The content of the sdo object.
@@ -923,7 +923,7 @@ cdef class CdefSlave:
             subindex (int): Subindex of the object.
             data (bytes): data to be written to the object.
             ca (:obj:`bool`, optional): complete access.
-            release_gil (:obj:`bool`, optional): True to write releasing the GIL. Defaults to False.
+            release_gil (:obj:`bool`, optional): True to write to a CoE object releasing the GIL. Defaults to False.
 
         Raises:
             SdoError: if write fails, the exception includes the SDO abort code  
@@ -1076,7 +1076,7 @@ cdef class CdefSlave:
             password (int): password for the target file, accepted range: 0 to 2^32 - 1
             data (bytes): data
             timeout (int): Timeout value in us
-            release_gil (:obj:`bool`, optional): True to write releasing the GIL. Defaults to False.
+            release_gil (:obj:`bool`, optional): True to FoE write releasing the GIL. Defaults to False.
         """
         # error handling
         if self._ecx_contextt == NULL:

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -845,7 +845,15 @@ cdef class CdefSlave:
                 PyMem_Free(pbuf)
 
     cdef int __sdo_write_nogil(self, uint16_t index, uint8_t subindex, int8_t ca, int size, bytes data):
-        """Write to a CoE object."""
+        """Write to a CoE object without GIL.
+        
+        Args:
+            index (int): Index of the object.
+            subindex (int): Subindex of the object.
+            ca (:obj:`bool`): complete access.
+            size (int): size of the data to be written.
+            data (bytes): data to be written to the object.
+        """
 
         cdef unsigned char* c_data = <unsigned char*> data
 
@@ -862,8 +870,8 @@ cdef class CdefSlave:
         Args:
             index (int): Index of the object.
             subindex (int): Subindex of the object.
-            data (bytes): data to be written to the object
-            ca (:obj:`bool`, optional): complete access
+            data (bytes): data to be written to the object.
+            ca (:obj:`bool`, optional): complete access.
             release_gil (:obj:`bool`, optional): True to write releasing the GIL. Defaults to False.
 
         Raises:

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -979,8 +979,6 @@ cdef class CdefSlave:
 
         cdef int result
         cdef int size = len(data)
-
-        print(f"RELEASE GIL: {release_gil}")
         
         if release_gil:
             result = self.__foe_write_nogil(filename, password, size, data, timeout)

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -28,6 +28,7 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from cpython.bytes cimport PyBytes_FromString, PyBytes_FromStringAndSize
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t
 from libc.string cimport memcpy, memset
+from cpython.ref cimport Py_INCREF, Py_DECREF
 
 logger = logging.getLogger(__name__)
 
@@ -955,9 +956,11 @@ cdef class CdefSlave:
         cdef bytes encoded_filename = filename.encode('utf-8')
         cdef char* c_filename = encoded_filename
         cdef unsigned char* c_data = <unsigned char*> data
-        
+
+        Py_INCREF(self)
         with nogil:
             result = cpysoem.ecx_FOEwrite(self._ecx_contextt, self._pos, c_filename, password, size, c_data, timeout)
+        Py_DECREF(self)
         
         return result
 

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -332,7 +332,7 @@ cdef class CdefMaster:
         
         return ret_val
 
-    cdef cpysoem.boolean check_release_gil(self, release_gil):
+    cpdef cpysoem.boolean check_release_gil(self, release_gil):
         """Checks if the GIL should be released.
 
         Args:
@@ -352,7 +352,7 @@ cdef class CdefMaster:
         Returns:
             int: Working counter of slave discover datagram = number of slaves found, -1 when no slave is connected
         """
-        release_gil = self.check_release_gil(release_gil=release_gil)
+        release_gil = self.check_release_gil(release_gil)
         self.check_context_is_initialized()
         self.slaves = []
         
@@ -514,7 +514,7 @@ cdef class CdefMaster:
         Returns:
             int: >0 if processdata is transmitted, might only by 0 if config map is not configured properly
         """
-        release_gil = self.check_release_gil(release_gil=release_gil)
+        release_gil = self.check_release_gil(release_gil)
         self.check_context_is_initialized()
         if release_gil:
             return self.__send_processdata_nogil()
@@ -557,7 +557,7 @@ cdef class CdefMaster:
         Returns
             int: Working Counter
         """
-        release_gil = self.check_release_gil(release_gil=release_gil)
+        release_gil = self.check_release_gil(release_gil)
         self.check_context_is_initialized()
         if release_gil:
             return self.__receive_processdata_nogil(timeout)


### PR DESCRIPTION
When using the `pysoem` library within threads, we've encountered situations where the Global Interpreter Lock (GIL) causes threads to block each other, leading to reduced performance and potential deadlocks. To mitigate this, we've enabled No-GIL support for specific functions that are safe to run without the GIL.

This new functionality can be controlled with an argument, which defaults to the current behavior (GIL-enabled).