### PR TITLE
Fix FoE error handling for non-existent files

### DIFF
--- a/src/pysoem/__init__.py
+++ b/src/pysoem/__init__.py
@@ -8,6 +8,7 @@ from pysoem.pysoem import (
     Emergency,
     SdoInfoError,
     MailboxError,
+    FoeError,
     PacketError,
     ConfigMapError,
     EepromError,

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -814,6 +814,22 @@ class EepromError(Exception):
     def __init__(self, message):
         self.message = message
 
+class FoeError(Exception):
+    """Errors during File over EtherCAT operations
+    
+    Attributes:
+        slave_pos (int): position of the slave
+        error_code (int): error code
+        desc (str): error description
+    """
+
+    def __init__(self, slave_pos, error_code, desc):
+        self.slave_pos = slave_pos
+        self.error_code = error_code
+        self.desc = desc
+        
+    def __str__(self):
+        return f"Slave {self.slave_pos}: FoE Error 0x{self.error_code:x} - {self.desc}"
 
 class WkcError(Exception):
     """Working counter error.
@@ -1207,6 +1223,19 @@ cdef class CdefSlave:
                 assert err.Slave == self._pos
                 self._raise_exception(&err)
 
+            # Check for negative return values from ecx_FOEwrite
+            if result < 0:
+                if result == -cpysoem.EC_ERR_TYPE_FOE_ERROR:
+                    raise FoeError(self._pos, result, "General FoE error")
+                elif result == -cpysoem.EC_ERR_TYPE_FOE_PACKETNUMBER:
+                    raise FoeError(self._pos, result, "Packet number error")
+                elif result == -cpysoem.EC_ERR_TYPE_FOE_FILE_NOTFOUND:
+                    raise FoeError(self._pos, result, "File not found or access denied")
+                elif result == -cpysoem.EC_ERR_TYPE_PACKET_ERROR:
+                    raise FoeError(self._pos, result, "Unexpected packet received")
+                else:
+                    raise FoeError(self._pos, result, "Unknown FoE error")
+
             return result
 
     cdef int __foe_read_nogil(self, str filename, uint32_t password, int size_inout, unsigned char* pbuf, int timeout):
@@ -1264,6 +1293,22 @@ cdef class CdefSlave:
                 PyMem_Free(pbuf)
                 assert err.Slave == self._pos
                 self._raise_exception(&err)
+
+            # Check for negative return values from ecx_FOEread
+            if result < 0:
+                PyMem_Free(pbuf)
+                if result == -cpysoem.EC_ERR_TYPE_FOE_ERROR:
+                    raise FoeError(self._pos, result, "File not found or access denied")
+                elif result == -cpysoem.EC_ERR_TYPE_FOE_BUF2SMALL:
+                    raise FoeError(self._pos, result, "Buffer too small for file content")
+                elif result == -cpysoem.EC_ERR_TYPE_FOE_PACKETNUMBER:
+                    raise FoeError(self._pos, result, "Packet number error")
+                elif result == -cpysoem.EC_ERR_TYPE_FOE_FILE_NOTFOUND:
+                    raise FoeError(self._pos, result, "File not found")
+                elif result == -cpysoem.EC_ERR_TYPE_PACKET_ERROR:
+                    raise FoeError(self._pos, result, "Unexpected packet received")
+                else:
+                    raise FoeError(self._pos, result, "Unknown FoE error")
 
             # return data
             try:

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -1298,7 +1298,7 @@ cdef class CdefSlave:
             if result < 0:
                 PyMem_Free(pbuf)
                 if result == -cpysoem.EC_ERR_TYPE_FOE_ERROR:
-                    raise FoeError(self._pos, result, "File not found or access denied")
+                    raise FoeError(self._pos, result, "General FoE error")
                 elif result == -cpysoem.EC_ERR_TYPE_FOE_BUF2SMALL:
                     raise FoeError(self._pos, result, "Buffer too small for file content")
                 elif result == -cpysoem.EC_ERR_TYPE_FOE_PACKETNUMBER:

--- a/tests/pysoem_foe_test.py
+++ b/tests/pysoem_foe_test.py
@@ -41,3 +41,15 @@ def test_foe_fails(pysoem_env):
     assert excinfo.value.error_code == 2
     assert excinfo.value.desc == 'The mailbox protocol is not supported'
 
+def test_foe_nonexistent_file(pysoem_env):
+    """Test that reading a non-existent file raises an appropriate exception."""
+    pysoem_env.config_init()
+    test_slave = pysoem_env.get_xmc_test_device()
+    
+    # Expect foe_read to fail for a non-existent file
+    with pytest.raises(pysoem.FoeError) as excinfo: 
+        test_slave.foe_read('nonexistent.bin', 0, 8192)
+
+    # Expect foe_write to fail for a non-existent file
+    with pytest.raises(pysoem.FoeError) as excinfo: 
+        test_slave.foe_write('nonexistent.bin', 0, b"test-data")


### PR DESCRIPTION
# Improved FoE Error Handling

## Problem
When attempting to read a non-existent file using `foe_read`, no exception is raised even though the device correctly returns a FoE ERROR response. This was observed in Wireshark captures where the device returns error code 32769 with a "filename not found" message, but the Python wrapper doesn't properly propagate this error.

## Solution
This PR adds proper error handling in the `foe_read` and `foe_write` functions to check the return values from the C functions. It also implements a new `FoeError` exception class to provide clear error information when FoE operations fail.

Changes:
- Created a `FoeError` class similar to other exception types in PySOEM
- Modified `foe_read` and `foe_write` to check for negative return values
- Added descriptive error messages based on the error codes
- Included a test case to verify non-existent file error handling

## Testing
I've tested this change with actual hardware and verified that proper exceptions are now raised when attempting to access non-existent files. The Wireshark captures confirm that the error handling correctly processes the device's error responses.

Let me know if you'd like any adjustments or have any questions!