### PR TITLE
Fix enum export issue caused by Cython 3.1.0 rc1

### DIFF
--- a/src/pysoem/__init__.py
+++ b/src/pysoem/__init__.py
@@ -41,34 +41,9 @@ from pysoem.pysoem import (
     ECT_COEDET_PDOCONFIG,
     ECT_COEDET_UPLOAD,
     ECT_COEDET_SDOCA,
-    ECT_BOOLEAN,
-    ECT_INTEGER8,
-    ECT_INTEGER16,
-    ECT_INTEGER32,
-    ECT_UNSIGNED8,
-    ECT_UNSIGNED16,
-    ECT_UNSIGNED32,
-    ECT_REAL32,
-    ECT_VISIBLE_STRING,
-    ECT_OCTET_STRING,
-    ECT_UNICODE_STRING,
-    ECT_TIME_OF_DAY,
-    ECT_TIME_DIFFERENCE,
-    ECT_DOMAIN,
-    ECT_INTEGER24,
-    ECT_REAL64,
-    ECT_INTEGER64,
-    ECT_UNSIGNED24,
-    ECT_UNSIGNED64,
-    ECT_BIT1,
-    ECT_BIT2,
-    ECT_BIT3,
-    ECT_BIT4,
-    ECT_BIT5,
-    ECT_BIT6,
-    ECT_BIT7,
-    ECT_BIT8,
+    ec_datatype
 )
+globals().update(ec_datatype.__members__)
 
 # Functions:
 from pysoem.pysoem import (


### PR DESCRIPTION
Fix below error on python3.13:
```
>>> import pysoem
Traceback (most recent call last):
  File "<python-input-24>", line 1, in <module>
    import pysoem
  File "<path>/lib/python3.13/site-packages/pysoem/__init__.py", line 32, in <module>
    from pysoem.pysoem import (
    ...<38 lines>...
    )
ImportError: cannot import name 'ECT_BOOLEAN' from 'pysoem.pysoem' (<path>/python3.13/site-packages/pysoem/pysoem.cpython-313-darwin.so)
```

After fix:
```
❯ python
Python 3.13.3 (main, Apr  8 2025, 13:54:08) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pysoem
>>> pysoem.ECT_
pysoem.ECT_BIT1                     pysoem.ECT_COEDET_PDOCONFIG         pysoem.ECT_INTEGER8                 pysoem.ECT_TIME_OF_DAY
pysoem.ECT_BIT2                     pysoem.ECT_COEDET_SDO               pysoem.ECT_OCTET_STRING             pysoem.ECT_UNICODE_STRING
pysoem.ECT_BIT3                     pysoem.ECT_COEDET_SDOCA             pysoem.ECT_REAL32                   pysoem.ECT_UNSIGNED16
pysoem.ECT_BIT4                     pysoem.ECT_COEDET_SDOINFO           pysoem.ECT_REAL64                   pysoem.ECT_UNSIGNED24
pysoem.ECT_BIT5                     pysoem.ECT_COEDET_UPLOAD            pysoem.ECT_REG_SM0                  pysoem.ECT_UNSIGNED32
pysoem.ECT_BIT6                     pysoem.ECT_DOMAIN                   pysoem.ECT_REG_SM1                  pysoem.ECT_UNSIGNED64
pysoem.ECT_BIT7                     pysoem.ECT_INTEGER16                pysoem.ECT_REG_WD_DIV               pysoem.ECT_UNSIGNED8
pysoem.ECT_BIT8                     pysoem.ECT_INTEGER24                pysoem.ECT_REG_WD_TIME_PDI          pysoem.ECT_VISIBLE_STRING
pysoem.ECT_BOOLEAN                  pysoem.ECT_INTEGER32                pysoem.ECT_REG_WD_TIME_PROCESSDATA
pysoem.ECT_COEDET_PDOASSIGN         pysoem.ECT_INTEGER64                pysoem.ECT_TIME_DIFFERENCE
```