### PR TITLE
bugfix: od:  return correct values for single access to 'obj_access'

### DIFF
--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -1528,6 +1528,9 @@ cdef class CdefCoeObject:
             return sum
     
     def _get_obj_access(self):
+        # read functions to return correct value if no previous access to other variables is done
+        self._read_description()
+        self._read_entries()
         if self._ex_odlist.MaxSub[self._item] == 0:
             return self._ex_oelist.ObjAccess[0]
         else:

--- a/tests/pysoem_coe_test.py
+++ b/tests/pysoem_coe_test.py
@@ -134,6 +134,14 @@ def test_write_timeout(pysoem_env):
     master.sdo_write_timeout = old_sdo_write_timeout
     assert master.sdo_write_timeout == 700000
 
+def test_sdo_obj_access(slaveDevice):
+    """Test single access to 'obj_access'
+
+    Args:
+        slaveDevice (_type_): pysoem slave device
+    """
+    obj_0x1000 = get_obj_from_od(slaveDevice.od, 0x1000)
+    assert obj_0x1000.obj_access == 0x0007
 
 def test_sdo_info_var(el1259):
 


### PR DESCRIPTION
- Fix single access to object directory value 'obj_access'
- Add test case to cover correct behaviour