### PR TITLE
safely manage open and close interface context

### DIFF
--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -23,6 +23,7 @@ import collections
 import time
 import contextlib
 import warnings
+import threading
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from cpython.bytes cimport PyBytes_FromString, PyBytes_FromStringAndSize
@@ -248,6 +249,9 @@ cdef class CdefMaster:
     cdef public int sdo_write_timeout
     cdef public cpysoem.boolean always_release_gil
     cdef readonly cpysoem.boolean context_initialized
+    cdef int _active_ops_count
+    cdef object _active_ops_zero_event
+    cdef cpysoem.boolean _closing
 
     state = property(_get_state, _set_state)
     expected_wkc  = property(_get_expected_wkc)
@@ -284,6 +288,10 @@ cdef class CdefMaster:
         self._settings.sdo_read_timeout = &self.sdo_read_timeout
         self._settings.sdo_write_timeout = &self.sdo_write_timeout
         self.context_initialized = False
+        self._active_ops_count = 0
+        self._active_ops_zero_event = threading.Event()
+        self._active_ops_zero_event.set()
+        self._closing = False
         
     def open(self, ifname, ifname_red=None):
         """Initialize and open network interface.
@@ -313,9 +321,26 @@ cdef class CdefMaster:
 
         self.context_initialized = True
 
-    def check_context_is_initialized(self):
+    @contextlib.contextmanager
+    def _operation_context(self):
+        """Context manager for guarding operations that require the context to be open.
+        
+        Checks that context is initialized and not closing, increments active operation counter 
+        on entry, decrements on exit (even if exception occurs).
+        Raises NetworkInterfaceNotOpenError if not initialized, RuntimeError if closing.
+        """
         if not self.context_initialized:
             raise NetworkInterfaceNotOpenError("SOEM Network interface is not initialized or has been closed. Call Master.open() first")
+        if self._closing:
+            raise RuntimeError("SOEM context is closing and cannot accept new operations")
+        self._active_ops_count += 1
+        self._active_ops_zero_event.clear()
+        try:
+            yield
+        finally:
+            self._active_ops_count -= 1
+            if self._active_ops_count == 0:
+                self._active_ops_zero_event.set()
 
     cdef int __config_init_nogil(self, uint8_t usetable):
         """Enumerate and init all slaves without GIL.
@@ -353,19 +378,19 @@ cdef class CdefMaster:
             int: Working counter of slave discover datagram = number of slaves found, -1 when no slave is connected
         """
         release_gil = self.check_release_gil(release_gil)
-        self.check_context_is_initialized()
-        self.slaves = []
-        
-        cdef int ret_val
-        if release_gil:
-            ret_val = self.__config_init_nogil(usetable)
-        else:
-            ret_val = cpysoem.ecx_config_init(&self._ecx_contextt, usetable)
+        with self._operation_context():
+            self.slaves = []
+            
+            cdef int ret_val
+            if release_gil:
+                ret_val = self.__config_init_nogil(usetable)
+            else:
+                ret_val = cpysoem.ecx_config_init(&self._ecx_contextt, usetable)
 
-        if ret_val > 0:
-          for i in range(self._ec_slavecount):
-              self.slaves.append(self._get_slave(i))
-        return ret_val
+            if ret_val > 0:
+              for i in range(self._ec_slavecount):
+                  self.slaves.append(self._get_slave(i))
+            return ret_val
         
     def config_map(self):
         """Map all slaves PDOs in IO map.
@@ -373,21 +398,21 @@ cdef class CdefMaster:
         Returns:
             int: IO map size (sum of all PDO in an out data)
         """
-        self.check_context_is_initialized()
-        cdef _CallbackData cd
-        # ecx_config_map_group returns the actual IO map size (not an error value), expect the value to be less than EC_IOMAPSIZE
-        ret_val = cpysoem.ecx_config_map_group(&self._ecx_contextt, &self.io_map, 0)
-        # check for exceptions raised in the config functions
-        for slave in self.slaves:
-            cd = slave._cd
-            if cd.exc_raised:
-                raise cd.exc_info[0], cd.exc_info[1], cd.exc_info[2]
-        logger.debug('io map size: {}'.format(ret_val))
-        # raise an exception if one or more mailbox errors occured within ecx_config_map_group call
-        error_list = self._collect_mailbox_errors()
-        if len(error_list) > 0:
-            raise ConfigMapError(error_list)
-        return ret_val
+        with self._operation_context():
+            cdef _CallbackData cd
+            # ecx_config_map_group returns the actual IO map size (not an error value), expect the value to be less than EC_IOMAPSIZE
+            ret_val = cpysoem.ecx_config_map_group(&self._ecx_contextt, &self.io_map, 0)
+            # check for exceptions raised in the config functions
+            for slave in self.slaves:
+                cd = slave._cd
+                if cd.exc_raised:
+                    raise cd.exc_info[0], cd.exc_info[1], cd.exc_info[2]
+            logger.debug('io map size: {}'.format(ret_val))
+            # raise an exception if one or more mailbox errors occured within ecx_config_map_group call
+            error_list = self._collect_mailbox_errors()
+            if len(error_list) > 0:
+                raise ConfigMapError(error_list)
+            return ret_val
         
     def config_overlap_map(self):
         """Map all slaves PDOs to overlapping IO map.
@@ -395,22 +420,22 @@ cdef class CdefMaster:
         Returns:
             int: IO map size (sum of all PDO in an out data)
         """
-        self.check_context_is_initialized()
-        cdef _CallbackData cd
-        # ecx_config_map_group returns the actual IO map size (not an error value), expect the value to be less than EC_IOMAPSIZE
-        ret_val = cpysoem.ecx_config_overlap_map_group(&self._ecx_contextt, &self.io_map, 0)
-        # check for exceptions raised in the config functions
-        for slave in self.slaves:
-            cd = slave._cd
-            if cd.exc_raised:
-                raise cd.exc_info[0],cd.exc_info[1],cd.exc_info[2]
-        logger.debug('io map size: {}'.format(ret_val))
-        # raise an exception if one or more mailbox errors occured within ecx_config_overlap_map_group call
-        error_list = self._collect_mailbox_errors()
-        if len(error_list) > 0:
-            raise ConfigMapError(error_list)
+        with self._operation_context():
+            cdef _CallbackData cd
+            # ecx_config_map_group returns the actual IO map size (not an error value), expect the value to be less than EC_IOMAPSIZE
+            ret_val = cpysoem.ecx_config_overlap_map_group(&self._ecx_contextt, &self.io_map, 0)
+            # check for exceptions raised in the config functions
+            for slave in self.slaves:
+                cd = slave._cd
+                if cd.exc_raised:
+                    raise cd.exc_info[0],cd.exc_info[1],cd.exc_info[2]
+            logger.debug('io map size: {}'.format(ret_val))
+            # raise an exception if one or more mailbox errors occured within ecx_config_overlap_map_group call
+            error_list = self._collect_mailbox_errors()
+            if len(error_list) > 0:
+                raise ConfigMapError(error_list)
 
-        return ret_val
+            return ret_val
 
     def _collect_mailbox_errors(self):
         # collect SDO or mailbox errors that occurred during PDO configuration read in ecx_config_map_group
@@ -439,13 +464,23 @@ cdef class CdefMaster:
         Returns:
             bool: if slaves are found with DC
         """
-        self.check_context_is_initialized()
-        return cpysoem.ecx_configdc(&self._ecx_contextt)
+        with self._operation_context():
+            return cpysoem.ecx_configdc(&self._ecx_contextt)
         
     def close(self):
         """Close the network interface.
         
+        Signals that no new operations should start and waits for any in-flight operations 
+        to complete before closing. Uses a timeout of 5 seconds; logs a warning if timeout occurs.
         """
+        self._closing = True
+        
+        # Wait for all active operations to complete
+        timeout = 5.0
+        if not self._active_ops_zero_event.wait(timeout=timeout):
+            logger.warning("Timeout waiting for active SOEM operations to complete during close(). "
+                          "There may be threads still accessing the context. Proceeding with close anyway.")
+        
         # ecx_close returns nothing
         self.context_initialized = False
         cpysoem.ecx_close(&self._ecx_contextt)
@@ -456,8 +491,8 @@ cdef class CdefMaster:
         Returns:
             int: lowest state found
         """
-        self.check_context_is_initialized()
-        return cpysoem.ecx_readstate(&self._ecx_contextt)
+        with self._operation_context():
+            return cpysoem.ecx_readstate(&self._ecx_contextt)
         
     def write_state(self):
         """Write all slaves state.
@@ -467,8 +502,8 @@ cdef class CdefMaster:
         Returns:
             int: Working counter or EC_NOFRAME
         """
-        self.check_context_is_initialized()
-        return cpysoem.ecx_writestate(&self._ecx_contextt, 0)
+        with self._operation_context():
+            return cpysoem.ecx_writestate(&self._ecx_contextt, 0)
         
     def state_check(self, int expected_state, timeout=50000):
         """Check actual slave state.
@@ -483,8 +518,8 @@ cdef class CdefMaster:
         Returns:
             int: Requested state, or found state after timeout
         """
-        self.check_context_is_initialized()
-        return cpysoem.ecx_statecheck(&self._ecx_contextt, 0, expected_state, timeout)
+        with self._operation_context():
+            return cpysoem.ecx_statecheck(&self._ecx_contextt, 0, expected_state, timeout)
 
     cdef int __send_processdata_nogil(self):
         """Transmit processdata to slaves without GIL."""
@@ -515,10 +550,10 @@ cdef class CdefMaster:
             int: >0 if processdata is transmitted, might only by 0 if config map is not configured properly
         """
         release_gil = self.check_release_gil(release_gil)
-        self.check_context_is_initialized()
-        if release_gil:
-            return self.__send_processdata_nogil()
-        return cpysoem.ecx_send_processdata(&self._ecx_contextt)
+        with self._operation_context():
+            if release_gil:
+                return self.__send_processdata_nogil()
+            return cpysoem.ecx_send_processdata(&self._ecx_contextt)
 
     cdef int __send_overlap_processdata_nogil(self):
         """Transmit overlap processdata to slaves without GIL."""
@@ -536,10 +571,10 @@ cdef class CdefMaster:
         Returns:
             int: >0 if processdata is transmitted, might only by 0 if config map is not configured properly
         """
-        self.check_context_is_initialized()
-        if release_gil:
-            return self.__send_overlap_processdata_nogil()
-        return cpysoem.ecx_send_overlap_processdata(&self._ecx_contextt)
+        with self._operation_context():
+            if release_gil:
+                return self.__send_overlap_processdata_nogil()
+            return cpysoem.ecx_send_overlap_processdata(&self._ecx_contextt)
 
     cdef int __receive_processdata_nogil(self, int timeout):
         """Receive processdata from slaves without GIL.
@@ -570,10 +605,10 @@ cdef class CdefMaster:
             int: Working Counter
         """
         release_gil = self.check_release_gil(release_gil)
-        self.check_context_is_initialized()
-        if release_gil:
-            return self.__receive_processdata_nogil(timeout)
-        return cpysoem.ecx_receive_processdata(&self._ecx_contextt, timeout)
+        with self._operation_context():
+            if release_gil:
+                return self.__receive_processdata_nogil(timeout)
+            return cpysoem.ecx_receive_processdata(&self._ecx_contextt, timeout)
     
     def _get_slave(self, int pos):
         if pos < 0:
@@ -882,49 +917,48 @@ cdef class CdefSlave:
         if self._ecx_contextt == NULL:
             raise UnboundLocalError()
 
-        self._master.check_context_is_initialized()
-        
-        cdef unsigned char* pbuf
-        cdef uint8_t std_buffer[STATIC_SDO_READ_BUFFER_SIZE]
-        cdef int size_inout
-        if size == 0:
-            pbuf = std_buffer
-            size_inout = STATIC_SDO_READ_BUFFER_SIZE
-        else:
-            pbuf = <unsigned char*>PyMem_Malloc((size)*sizeof(unsigned char))
-            size_inout = size
-        
-        if pbuf == NULL:
-            raise MemoryError()
-        
-        cdef int result
-        if release_gil:
-            result = self.__sdo_read_nogil(index, subindex, ca, &size_inout, pbuf)
-        else:
-            result = cpysoem.ecx_SDOread(self._ecx_contextt, self._pos, index, subindex, ca,
-                                              &size_inout, pbuf, self._the_masters_settings.sdo_read_timeout[0])
-
-        cdef cpysoem.ec_errort err
-        while cpysoem.ecx_poperror(self._ecx_contextt, &err):
-            assert err.Slave == self._pos
-
-            if (err.Etype == cpysoem.EC_ERR_TYPE_EMERGENCY) and (len(self._emcy_callbacks) > 0):
-                self._on_emergency(&err)
+        with self._master._operation_context():
+            cdef unsigned char* pbuf
+            cdef uint8_t std_buffer[STATIC_SDO_READ_BUFFER_SIZE]
+            cdef int size_inout
+            if size == 0:
+                pbuf = std_buffer
+                size_inout = STATIC_SDO_READ_BUFFER_SIZE
             else:
+                pbuf = <unsigned char*>PyMem_Malloc((size)*sizeof(unsigned char))
+                size_inout = size
+            
+            if pbuf == NULL:
+                raise MemoryError()
+            
+            cdef int result
+            if release_gil:
+                result = self.__sdo_read_nogil(index, subindex, ca, &size_inout, pbuf)
+            else:
+                result = cpysoem.ecx_SDOread(self._ecx_contextt, self._pos, index, subindex, ca,
+                                                  &size_inout, pbuf, self._the_masters_settings.sdo_read_timeout[0])
+
+            cdef cpysoem.ec_errort err
+            while cpysoem.ecx_poperror(self._ecx_contextt, &err):
+                assert err.Slave == self._pos
+
+                if (err.Etype == cpysoem.EC_ERR_TYPE_EMERGENCY) and (len(self._emcy_callbacks) > 0):
+                    self._on_emergency(&err)
+                else:
+                    if pbuf != std_buffer:
+                        PyMem_Free(pbuf)
+                    self._raise_exception(&err)
+
+            if not result > 0:
+                if pbuf != std_buffer:
+                        PyMem_Free(pbuf)
+                raise WkcError(wkc=result)
+
+            try:
+                return PyBytes_FromStringAndSize(<char*>pbuf, size_inout)
+            finally:
                 if pbuf != std_buffer:
                     PyMem_Free(pbuf)
-                self._raise_exception(&err)
-
-        if not result > 0:
-            if pbuf != std_buffer:
-                    PyMem_Free(pbuf)
-            raise WkcError(wkc=result)
-
-        try:
-            return PyBytes_FromStringAndSize(<char*>pbuf, size_inout)
-        finally:
-            if pbuf != std_buffer:
-                PyMem_Free(pbuf)
 
     cdef int __sdo_write_nogil(self, uint16_t index, uint8_t subindex, int8_t ca, int size, bytes data):
         """Write to a CoE object without GIL.
@@ -963,25 +997,25 @@ cdef class CdefSlave:
             WkcError: if working counter is not higher than 0, the exception includes the working counter
         """
         release_gil = self._master.check_release_gil(release_gil=release_gil)
-        self._master.check_context_is_initialized()
 
-        cdef int size = len(data)
-        cdef int result
-        if release_gil:
-            result = self.__sdo_write_nogil(index, subindex, ca, size, data)
-        else:
-            result = cpysoem.ecx_SDOwrite(self._ecx_contextt, self._pos, index, subindex, ca,
-                                               size, <unsigned char*>data, self._the_masters_settings.sdo_write_timeout[0])
-        
-        cdef cpysoem.ec_errort err
-        while(cpysoem.ecx_poperror(self._ecx_contextt, &err)):
-            if (err.Etype == cpysoem.EC_ERR_TYPE_EMERGENCY) and (len(self._emcy_callbacks) > 0):
-                self._on_emergency(&err)
+        with self._master._operation_context():
+            cdef int size = len(data)
+            cdef int result
+            if release_gil:
+                result = self.__sdo_write_nogil(index, subindex, ca, size, data)
             else:
-                self._raise_exception(&err)
+                result = cpysoem.ecx_SDOwrite(self._ecx_contextt, self._pos, index, subindex, ca,
+                                                   size, <unsigned char*>data, self._the_masters_settings.sdo_write_timeout[0])
+            
+            cdef cpysoem.ec_errort err
+            while(cpysoem.ecx_poperror(self._ecx_contextt, &err)):
+                if (err.Etype == cpysoem.EC_ERR_TYPE_EMERGENCY) and (len(self._emcy_callbacks) > 0):
+                    self._on_emergency(&err)
+                else:
+                    self._raise_exception(&err)
 
-        if not result > 0:
-            raise WkcError(wkc=result)
+            if not result > 0:
+                raise WkcError(wkc=result)
 
     def mbx_receive(self):
         """Read out the slaves out mailbox - to check for emergency messages.
@@ -992,20 +1026,19 @@ cdef class CdefSlave:
         :rtype: int
         :raises Emergency: if an emergency message was received
         """
-        self._master.check_context_is_initialized()
+        with self._master._operation_context():
+            cdef cpysoem.ec_mbxbuft buf
+            cpysoem.ec_clearmbx(&buf)
+            cdef int wkt = cpysoem.ecx_mbxreceive(self._ecx_contextt, self._pos, &buf, 0)
 
-        cdef cpysoem.ec_mbxbuft buf
-        cpysoem.ec_clearmbx(&buf)
-        cdef int wkt = cpysoem.ecx_mbxreceive(self._ecx_contextt, self._pos, &buf, 0)
+            cdef cpysoem.ec_errort err
+            if cpysoem.ecx_poperror(self._ecx_contextt, &err):
+                if (err.Etype == cpysoem.EC_ERR_TYPE_EMERGENCY) and (len(self._emcy_callbacks) > 0):
+                    self._on_emergency(&err)
+                else:
+                    self._raise_exception(&err)
 
-        cdef cpysoem.ec_errort err
-        if cpysoem.ecx_poperror(self._ecx_contextt, &err):
-            if (err.Etype == cpysoem.EC_ERR_TYPE_EMERGENCY) and (len(self._emcy_callbacks) > 0):
-                self._on_emergency(&err)
-            else:
-                self._raise_exception(&err)
-
-        return wkt
+            return wkt
         
     def write_state(self):
         """Write slave state.
@@ -1116,23 +1149,22 @@ cdef class CdefSlave:
         if self._ecx_contextt == NULL:
             raise UnboundLocalError()
 
-        self._master.check_context_is_initialized()
+        with self._master._operation_context():
+            cdef int result
+            cdef int size = len(data)
+            
+            if release_gil:
+                result = self.__foe_write_nogil(filename, password, size, data, timeout)
+            else:
+                result = cpysoem.ecx_FOEwrite(self._ecx_contextt, self._pos, filename.encode('utf8'), password, size, <unsigned char*>data, timeout)
+            
+            # error handling
+            cdef cpysoem.ec_errort err
+            if cpysoem.ecx_poperror(self._ecx_contextt, &err):
+                assert err.Slave == self._pos
+                self._raise_exception(&err)
 
-        cdef int result
-        cdef int size = len(data)
-        
-        if release_gil:
-            result = self.__foe_write_nogil(filename, password, size, data, timeout)
-        else:
-            result = cpysoem.ecx_FOEwrite(self._ecx_contextt, self._pos, filename.encode('utf8'), password, size, <unsigned char*>data, timeout)
-        
-        # error handling
-        cdef cpysoem.ec_errort err
-        if cpysoem.ecx_poperror(self._ecx_contextt, &err):
-            assert err.Slave == self._pos
-            self._raise_exception(&err)
-
-        return result
+            return result
 
     cdef int __foe_read_nogil(self, str filename, uint32_t password, int size_inout, unsigned char* pbuf, int timeout):
         """Read given filename from device using FoE without GIL.
@@ -1169,32 +1201,31 @@ cdef class CdefSlave:
         if self._ecx_contextt == NULL:
             raise UnboundLocalError()
 
-        self._master.check_context_is_initialized()
+        with self._master._operation_context():
+            # prepare call of c function
+            cdef unsigned char* pbuf
+            cdef int size_inout
+            pbuf = <unsigned char*>PyMem_Malloc((size)*sizeof(unsigned char))
+            size_inout = size
 
-        # prepare call of c function
-        cdef unsigned char* pbuf
-        cdef int size_inout
-        pbuf = <unsigned char*>PyMem_Malloc((size)*sizeof(unsigned char))
-        size_inout = size
+            cdef int result
+            if release_gil:
+                result = self.__foe_read_nogil(filename, password, size_inout, pbuf, timeout)
+            else:
+                result = cpysoem.ecx_FOEread(self._ecx_contextt, self._pos, filename.encode('utf8'), password, &size_inout, pbuf, timeout)
 
-        cdef int result
-        if release_gil:
-            result = self.__foe_read_nogil(filename, password, size_inout, pbuf, timeout)
-        else:
-            result = cpysoem.ecx_FOEread(self._ecx_contextt, self._pos, filename.encode('utf8'), password, &size_inout, pbuf, timeout)
+            # error handling
+            cdef cpysoem.ec_errort err
+            if cpysoem.ecx_poperror(self._ecx_contextt, &err):
+                PyMem_Free(pbuf)
+                assert err.Slave == self._pos
+                self._raise_exception(&err)
 
-        # error handling
-        cdef cpysoem.ec_errort err
-        if cpysoem.ecx_poperror(self._ecx_contextt, &err):
-            PyMem_Free(pbuf)
-            assert err.Slave == self._pos
-            self._raise_exception(&err)
-
-        # return data
-        try:
-            return PyBytes_FromStringAndSize(<char*>pbuf, size_inout)
-        finally:
-            PyMem_Free(pbuf)
+            # return data
+            try:
+                return PyBytes_FromStringAndSize(<char*>pbuf, size_inout)
+            finally:
+                PyMem_Free(pbuf)
 
     def amend_mbx(self, mailbox, start_address, size):
         """Change the start address and size of a mailbox.
@@ -1207,33 +1238,32 @@ cdef class CdefSlave:
 
         .. versionadded:: 1.0.6
         """
-        self._master.check_context_is_initialized()
-
-        fpwr_timeout_us = 4000
-        if mailbox == 'out':
-            # Clear the slaves mailbox configuration.
-            self._fpwr(ECT_REG_SM0, bytes(sizeof(self._ec_slave.SM[0])))
-            self._ec_slave.SM[0].StartAddr = start_address
-            self._ec_slave.SM[0].SMlength = size
-            self._ec_slave.mbx_wo = start_address
-            self._ec_slave.mbx_l = size
-            # Update the slaves mailbox configuration.
-            self._fpwr(ECT_REG_SM0,
-                       PyBytes_FromStringAndSize(<char*>&self._ec_slave.SM[0], sizeof(self._ec_slave.SM[0])),
-                       fpwr_timeout_us)
-        elif mailbox == 'in':
-            # Clear the slaves mailbox configuration.
-            self._fpwr(ECT_REG_SM1, bytes(sizeof(self._ec_slave.SM[1])))
-            self._ec_slave.SM[1].StartAddr = start_address
-            self._ec_slave.SM[1].SMlength = size
-            self._ec_slave.mbx_ro = start_address
-            self._ec_slave.mbx_rl = size
-            # Update the slaves mailbox configuration.
-            self._fpwr(ECT_REG_SM1,
-                       PyBytes_FromStringAndSize(<char*>&self._ec_slave.SM[1], sizeof(self._ec_slave.SM[1])),
-                       fpwr_timeout_us)
-        else:
-            raise AttributeError()
+        with self._master._operation_context():
+            fpwr_timeout_us = 4000
+            if mailbox == 'out':
+                # Clear the slaves mailbox configuration.
+                self._fpwr(ECT_REG_SM0, bytes(sizeof(self._ec_slave.SM[0])))
+                self._ec_slave.SM[0].StartAddr = start_address
+                self._ec_slave.SM[0].SMlength = size
+                self._ec_slave.mbx_wo = start_address
+                self._ec_slave.mbx_l = size
+                # Update the slaves mailbox configuration.
+                self._fpwr(ECT_REG_SM0,
+                           PyBytes_FromStringAndSize(<char*>&self._ec_slave.SM[0], sizeof(self._ec_slave.SM[0])),
+                           fpwr_timeout_us)
+            elif mailbox == 'in':
+                # Clear the slaves mailbox configuration.
+                self._fpwr(ECT_REG_SM1, bytes(sizeof(self._ec_slave.SM[1])))
+                self._ec_slave.SM[1].StartAddr = start_address
+                self._ec_slave.SM[1].SMlength = size
+                self._ec_slave.mbx_ro = start_address
+                self._ec_slave.mbx_rl = size
+                # Update the slaves mailbox configuration.
+                self._fpwr(ECT_REG_SM1,
+                           PyBytes_FromStringAndSize(<char*>&self._ec_slave.SM[1], sizeof(self._ec_slave.SM[1])),
+                           fpwr_timeout_us)
+            else:
+                raise AttributeError()
 
     def set_watchdog(self, wd_type, wd_time_ms):
         """Change the watchdog time of the PDI or Process Data watchdog.

--- a/src/pysoem/pysoem.pyx
+++ b/src/pysoem/pysoem.pyx
@@ -320,6 +320,7 @@ cdef class CdefMaster:
             raise ConnectionError('could not open interface {}'.format(ifname))
 
         self.context_initialized = True
+        self._closing = False
 
     @contextlib.contextmanager
     def _operation_context(self):
@@ -484,6 +485,8 @@ cdef class CdefMaster:
         # ecx_close returns nothing
         self.context_initialized = False
         cpysoem.ecx_close(&self._ecx_contextt)
+        self._closing = False
+        
 
     def read_state(self):
         """Read all slaves states.

--- a/tests/test_operation_counter.py
+++ b/tests/test_operation_counter.py
@@ -1,0 +1,219 @@
+"""Unit tests for _OperationCounter class."""
+
+import pytest
+import threading
+import time
+from pysoem.pysoem import OperationCounter
+
+
+def test_initial_state():
+    """Test that counter starts at zero with event set."""
+    counter = OperationCounter()
+    # Should be able to wait immediately since count is 0
+    assert counter.wait_for_zero(timeout=0.001)
+
+
+def test_increment_decrement():
+    """Test basic increment and decrement operations."""
+    counter = OperationCounter()
+    
+    counter.increment()
+    # Should not be at zero anymore
+    assert not counter.wait_for_zero(timeout=0.001)
+    
+    counter.decrement()
+    # Should be back at zero
+    assert counter.wait_for_zero(timeout=0.001)
+
+
+def test_multiple_increments():
+    """Test multiple increments before decrements."""
+    counter = OperationCounter()
+    
+    counter.increment()
+    counter.increment()
+    counter.increment()
+    
+    # Still not at zero
+    assert not counter.wait_for_zero(timeout=0.001)
+    
+    counter.decrement()
+    assert not counter.wait_for_zero(timeout=0.001)
+    
+    counter.decrement()
+    assert not counter.wait_for_zero(timeout=0.001)
+    
+    counter.decrement()
+    # Now at zero
+    assert counter.wait_for_zero(timeout=0.001)
+
+
+def test_reset():
+    """Test reset operation."""
+    counter = OperationCounter()
+    
+    counter.increment()
+    counter.increment()
+    counter.increment()
+    
+    # Not at zero
+    assert not counter.wait_for_zero(timeout=0.001)
+    
+    counter.reset()
+    # Reset should set to zero
+    assert counter.wait_for_zero(timeout=0.001)
+
+
+def test_threaded_increment_decrement():
+    """Test thread safety of increment and decrement."""
+    counter = OperationCounter()
+    num_threads = 10
+    iterations = 100
+    
+    def worker():
+        for _ in range(iterations):
+            counter.increment()
+            time.sleep(0.0001)  # Small delay to encourage interleaving
+            counter.decrement()
+    
+    threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+    
+    for t in threads:
+        t.start()
+    
+    for t in threads:
+        t.join()
+    
+    # After all operations, should be back at zero
+    assert counter.wait_for_zero(timeout=1.0)
+
+
+def test_wait_for_zero_blocks():
+    """Test that wait_for_zero blocks until count reaches zero."""
+    counter = OperationCounter()
+    counter.increment()
+    
+    result = []
+    
+    def waiter():
+        # This should block until decrement is called
+        success = counter.wait_for_zero(timeout=2.0)
+        result.append(success)
+    
+    def decrementer():
+        time.sleep(0.1)  # Wait a bit before decrementing
+        counter.decrement()
+    
+    wait_thread = threading.Thread(target=waiter)
+    dec_thread = threading.Thread(target=decrementer)
+    
+    start = time.time()
+    wait_thread.start()
+    dec_thread.start()
+    
+    wait_thread.join()
+    dec_thread.join()
+    elapsed = time.time() - start
+    
+    # Should have waited at least 0.1 seconds
+    assert elapsed >= 0.1
+    # Should have succeeded
+    assert result[0] is True
+
+
+def test_wait_for_zero_timeout():
+    """Test that wait_for_zero times out correctly."""
+    counter = OperationCounter()
+    counter.increment()
+    
+    start = time.time()
+    result = counter.wait_for_zero(timeout=0.1)
+    elapsed = time.time() - start
+    
+    # Should have timed out
+    assert result is False
+    # Should have waited approximately the timeout duration
+    assert 0.09 < elapsed < 0.2
+
+
+def test_concurrent_operations():
+    """Test concurrent increments and decrements."""
+    counter = OperationCounter()
+    num_threads = 20
+    operations_per_thread = 50
+    
+    barrier = threading.Barrier(num_threads)
+    
+    def worker():
+        # Synchronize start to maximize contention
+        barrier.wait()
+        for _ in range(operations_per_thread):
+            counter.increment()
+            counter.decrement()
+    
+    threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+    
+    for t in threads:
+        t.start()
+    
+    for t in threads:
+        t.join()
+    
+    # Should be at zero after all operations
+    assert counter.wait_for_zero(timeout=1.0)
+
+
+def test_event_cleared_on_first_increment():
+    """Test that event is cleared only on first increment from zero."""
+    counter = OperationCounter()
+    
+    # Initially at zero, event should be set
+    assert counter.wait_for_zero(timeout=0.001)
+    
+    # First increment should clear the event
+    counter.increment()
+    assert not counter.wait_for_zero(timeout=0.001)
+    
+    # Subsequent increments should keep it cleared
+    counter.increment()
+    assert not counter.wait_for_zero(timeout=0.001)
+    
+    # Decrement but not to zero
+    counter.decrement()
+    assert not counter.wait_for_zero(timeout=0.001)
+    
+    # Final decrement to zero should set the event
+    counter.decrement()
+    assert counter.wait_for_zero(timeout=0.001)
+
+
+def test_multiple_waiters():
+    """Test that multiple threads can wait for zero."""
+    counter = OperationCounter()
+    counter.increment()
+    
+    results = []
+    
+    def waiter(index):
+        success = counter.wait_for_zero(timeout=2.0)
+        results.append((index, success))
+    
+    # Create multiple waiters
+    num_waiters = 5
+    waiters = [threading.Thread(target=waiter, args=(i,)) for i in range(num_waiters)]
+    
+    for t in waiters:
+        t.start()
+    
+    # Wait a bit to ensure all waiters are blocked
+    time.sleep(0.05)
+    
+    # Decrement to zero - should wake all waiters
+    counter.decrement()
+    
+    for t in waiters:
+        t.join()
+    
+    # All waiters should have succeeded
+    assert len(results) == num_waiters
+    assert all(success for _, success in results)


### PR DESCRIPTION
Hi, I previously contributed with this PR: https://github.com/bnjmnp/pysoem/pull/156 which has prevented a lot of crashes in the applications/scripts I do. However, I've detected there's a very small race condition that I would like to address.

## The Problem

A race condition occurs when `close()` is called while another thread executes an SDO transaction or other context-dependent operation:

1. Thread A acquires critical section locks during SDO operation
2. Thread B calls `close()` and destroys those locks
3. Thread A waits indefinitely on a lock that no longer exists
4. Result: hangs, crashes, undefined behavior

https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-deletecriticalsection
"If a critical section is deleted while it is still owned, the state of the threads waiting for ownership of the deleted critical section is undefined."

## The Solution

Implement a **GIL-protected operation counter** with timeout-based close handshake:

- **On operation start**: Increment counter, reject if closing
- **On operation end**: Decrement counter, signal event when zero
- **On close**: Set closing flag, wait up to 5 seconds for counter to reach zero, then cleanup regardless