### PR TITLE
Clean up basic example

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -138,7 +138,8 @@ class BasicExample:
             self._master.close()
             raise BasicExampleError("not all slaves reached SAFEOP state")
         
-        slave.dc_sync(act=True, sync0_cycle_time=10_000_000)  # time is given in ns -> 10,000,000ns = 10ms
+        for slave in self._master.slaves:
+            slave.dc_sync(act=True, sync0_cycle_time=10_000_000)  # time is given in ns -> 10,000,000ns = 10ms
 
         self._master.state = pysoem.OP_STATE
 

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -30,9 +30,9 @@ EL1259_PRODUCT_CODE = 0x04EB_3052
 class Device:
     """Definition of a slave device on the EtherCAT network."""
     name: str
-    vendor_id: int
-    product_code: int
-    config_func: typing.Callable = None
+    vendor_id: int  # EtherCAT vendor ID (Object 0x1018:1)
+    product_code: int  # EtherCAT product code (Object 0x1018:2)
+    config_func: typing.Callable = None  # Called during Pre-Op -> Safe-Op transition.
 
 
 class BasicExample:
@@ -42,12 +42,17 @@ class BasicExample:
         """Create the example using the given adapter and secondary adapter for redundancy."""
         self._ifname = ifname
         self._ifname_red = ifname_red
+        self._actual_wkc = 0  # Measured working counter value.
+
+        # Stop flags for background threads.
         self._pd_thread_stop_event = threading.Event()
         self._ch_thread_stop_event = threading.Event()
-        self._actual_wkc = 0
+
+        # Initialize the master.
         self._master = pysoem.Master()
         self._master.in_op = False
         self._master.do_check_state = False
+
         self._expected_slave_layout = {
             0: Device("EK1100", BECKHOFF_VENDOR_ID, EK1100_PRODUCT_CODE),
             1: Device("EL3002", BECKHOFF_VENDOR_ID, EL3002_PRODUCT_CODE),
@@ -82,6 +87,8 @@ class BasicExample:
         ]
         rx_map_obj_bytes = struct.pack(
             "Bx" + "".join(["H" for _ in range(len(rx_map_obj))]), len(rx_map_obj), *rx_map_obj)
+
+        # Assign rx PDOs.
         slave.sdo_write(index=0x1C12, subindex=0, data=rx_map_obj_bytes, ca=True)
 
     def _processdata_thread(self) -> None:
@@ -89,6 +96,8 @@ class BasicExample:
         while not self._pd_thread_stop_event.is_set():
             self._master.send_processdata()
             self._actual_wkc = self._master.receive_processdata(timeout=100_000)
+
+            # Check working counter.
             if not self._actual_wkc == self._master.expected_wkc:
                 print("incorrect wkc")
             time.sleep(0.01)
@@ -126,10 +135,12 @@ class BasicExample:
         """Run the example, starting the EtherCAT connection."""
         self._master.open(self._ifname, self._ifname_red)
 
+        # Populate all slaves on the network.
         if not self._master.config_init() > 0:
             self._master.close()
             raise BasicExampleError("no slave found")
 
+        # Validate each slave based on the expected configuration.
         for i, slave in enumerate(self._master.slaves):
             if not ((slave.man == self._expected_slave_layout[i].vendor_id) and
                     (slave.id == self._expected_slave_layout[i].product_code)):
@@ -138,8 +149,10 @@ class BasicExample:
             slave.config_func = self._expected_slave_layout[i].config_func
             slave.is_lost = False
 
+        # Map PDO Data.
         self._master.config_map()
 
+        # Setup distributed clocks.
         for slave in self._master.slaves:
             slave.dc_sync(act=True, sync0_cycle_time=10_000_000)  # time is given in ns -> 10,000,000ns = 10ms
 
@@ -164,6 +177,7 @@ class BasicExample:
 
         self._master.write_state()
 
+        # Sometimes slaves will not reach OP on the first attempt. Retry as needed.
         all_slaves_reached_op_state = False
         for i in range(40):
             self._master.state_check(pysoem.OP_STATE, timeout=50_000)
@@ -174,6 +188,7 @@ class BasicExample:
         if all_slaves_reached_op_state:
             self._pdo_update_loop()
 
+        # Cleanup on exiting
         self._pd_thread_stop_event.set()
         self._ch_thread_stop_event.set()
         proc_thread.join()
@@ -218,9 +233,12 @@ class BasicExample:
     def _check_thread(self) -> None:
         """Background thread that cyclically checks for network errors at a 10ms interval."""
         while not self._ch_thread_stop_event.is_set():
+            # Check for working counter errors.
             if self._master.in_op and ((self._actual_wkc < self._master.expected_wkc) or self._master.do_check_state):
                 self._master.do_check_state = False
                 self._master.read_state()
+
+                # Check that all slaves are ok.
                 for i, slave in enumerate(self._master.slaves):
                     if slave.state != pysoem.OP_STATE:
                         self._master.do_check_state = True

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -134,12 +134,12 @@ class BasicExample:
 
         self._master.config_map()
 
+        for slave in self._master.slaves:
+            slave.dc_sync(act=True, sync0_cycle_time=10_000_000)  # time is given in ns -> 10,000,000ns = 10ms
+
         if self._master.state_check(pysoem.SAFEOP_STATE, timeout=50_000) != pysoem.SAFEOP_STATE:
             self._master.close()
             raise BasicExampleError("not all slaves reached SAFEOP state")
-        
-        for slave in self._master.slaves:
-            slave.dc_sync(act=True, sync0_cycle_time=10_000_000)  # time is given in ns -> 10,000,000ns = 10ms
 
         self._master.state = pysoem.OP_STATE
 

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -137,6 +137,9 @@ class BasicExample:
         for slave in self._master.slaves:
             slave.dc_sync(act=True, sync0_cycle_time=10_000_000)  # time is given in ns -> 10,000,000ns = 10ms
 
+        dc_devices = self._master.config_dc()
+        print(f"Configured DC. Found {dc_devices} compatible devices")
+
         if self._master.state_check(pysoem.SAFEOP_STATE, timeout=50_000) != pysoem.SAFEOP_STATE:
             self._master.close()
             raise BasicExampleError("not all slaves reached SAFEOP state")

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -28,6 +28,7 @@ EL1259_PRODUCT_CODE = 0x04EB_3052
 
 @dataclasses.dataclass
 class Device:
+    """Definition of a slave device on the EtherCAT network."""
     name: str
     vendor_id: int
     product_code: int
@@ -35,7 +36,10 @@ class Device:
 
 
 class BasicExample:
+    """An instance of the basic example."""
+
     def __init__(self, ifname: str, ifname_red: str) -> None:
+        """Create the example using the given adapter and secondary adapter for redundancy."""
         self._ifname = ifname
         self._ifname_red = ifname_red
         self._pd_thread_stop_event = threading.Event()
@@ -119,6 +123,7 @@ class BasicExample:
             print("stopped")
 
     def run(self) -> None:
+        """Run the example, starting the EtherCAT connection."""
         self._master.open(self._ifname, self._ifname_red)
 
         if not self._master.config_init() > 0:
@@ -183,6 +188,7 @@ class BasicExample:
 
     @staticmethod
     def _check_slave(slave: CdefSlave, pos: int) -> None:
+        """Check what error state the slave is in, and try to recover if possible."""
         if slave.state == (pysoem.SAFEOP_STATE + pysoem.STATE_ERROR):
             print(f"ERROR : slave {pos} is in SAFE_OP + ERROR, attempting ack.")
             slave.state = pysoem.SAFEOP_STATE + pysoem.STATE_ACK
@@ -210,6 +216,7 @@ class BasicExample:
                 print(f"MESSAGE : slave {pos} found")
 
     def _check_thread(self) -> None:
+        """Background thread that cyclically checks for network errors at a 10ms interval."""
         while not self._ch_thread_stop_event.is_set():
             if self._master.in_op and ((self._actual_wkc < self._master.expected_wkc) or self._master.do_check_state):
                 self._master.do_check_state = False
@@ -224,6 +231,7 @@ class BasicExample:
 
 
 class BasicExampleError(Exception):
+    """Generic exception type for the basic example."""
     def __init__(self, message: str) -> None:
         super().__init__(message)
         self.message = message

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -17,6 +17,7 @@ import argparse
 
 
 import pysoem
+from pysoem import CdefSlave
 
 
 BECKHOFF_VENDOR_ID = 0x0000_0002
@@ -34,7 +35,7 @@ class Device:
 
 
 class BasicExample:
-    def __init__(self, ifname, ifname_red):
+    def __init__(self, ifname: str, ifname_red: str) -> None:
         self._ifname = ifname
         self._ifname_red = ifname_red
         self._pd_thread_stop_event = threading.Event()
@@ -49,7 +50,7 @@ class BasicExample:
             2: Device("EL1259", BECKHOFF_VENDOR_ID, EL1259_PRODUCT_CODE, self.el1259_setup)
         }
 
-    def el1259_setup(self, slave_pos):
+    def el1259_setup(self, slave_pos: int) -> None:
         """Config function that will be called when transitioning from PreOP state to SafeOP state."""
         slave = self._master.slaves[slave_pos]
 
@@ -79,7 +80,7 @@ class BasicExample:
             "Bx" + "".join(["H" for _ in range(len(rx_map_obj))]), len(rx_map_obj), *rx_map_obj)
         slave.sdo_write(index=0x1C12, subindex=0, data=rx_map_obj_bytes, ca=True)
 
-    def _processdata_thread(self):
+    def _processdata_thread(self) -> None:
         """Background thread that sends and receives the process-data frame in a 10ms interval."""
         while not self._pd_thread_stop_event.is_set():
             self._master.send_processdata()
@@ -88,7 +89,7 @@ class BasicExample:
                 print("incorrect wkc")
             time.sleep(0.01)
 
-    def _pdo_update_loop(self):
+    def _pdo_update_loop(self) -> None:
         """The actual application code used to toggle the digital output at the EL1259 in an endless loop.
 
         Called when all slaves reached OP state.
@@ -117,7 +118,7 @@ class BasicExample:
             # ctrl-C abort handling
             print("stopped")
 
-    def run(self):
+    def run(self) -> None:
         self._master.open(self._ifname, self._ifname_red)
 
         if not self._master.config_init() > 0:
@@ -181,7 +182,7 @@ class BasicExample:
             raise BasicExampleError("not all slaves reached OP state")
 
     @staticmethod
-    def _check_slave(slave, pos):
+    def _check_slave(slave: CdefSlave, pos: int) -> None:
         if slave.state == (pysoem.SAFEOP_STATE + pysoem.STATE_ERROR):
             print(f"ERROR : slave {pos} is in SAFE_OP + ERROR, attempting ack.")
             slave.state = pysoem.SAFEOP_STATE + pysoem.STATE_ACK
@@ -208,7 +209,7 @@ class BasicExample:
                 slave.is_lost = False
                 print(f"MESSAGE : slave {pos} found")
 
-    def _check_thread(self):
+    def _check_thread(self) -> None:
         while not self._ch_thread_stop_event.is_set():
             if self._master.in_op and ((self._actual_wkc < self._master.expected_wkc) or self._master.do_check_state):
                 self._master.do_check_state = False
@@ -223,7 +224,7 @@ class BasicExample:
 
 
 class BasicExampleError(Exception):
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         super().__init__(message)
         self.message = message
 


### PR DESCRIPTION
I noticed a bug in the basic example, and also wanted to do a bit of minor cleanup while I was at it. Look at each commit in order and it should be clear what's going on.

- See the first commit: this should fix the primary bug.
- As far as I can tell, DC should also be enabled prior to transitioning to SafeOP.
- It's unclear to me whether `master.config_dc()` actually needs to be called, but it appears to be in [SOEM's example](https://github.com/OpenEtherCATsociety/SOEM/blob/master/samples/ec_sample/ec_sample.c#L209). Including the call doesn't appear to hurt, and it's possible that leaving it out may cause problems in some cases.

The other commits are just formatting and comments. I think many people viewing this project are newer to EtherCAT, and will benefit from additional comments.